### PR TITLE
Manage callback queues.

### DIFF
--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		7791E60F21FE862600957650 /* TezosKitExample.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = TezosKitExample.playground; path = Examples/TezosKitExample.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		77CE359621F7DC76006ADABA /* TezosKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TezosKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE359F21F7DC76006ADABA /* TezosKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TezosKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE35A621F7DC76006ADABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -253,6 +254,7 @@
 		77CE358C21F7DC76006ADABA = {
 			isa = PBXGroup;
 			children = (
+				7791E60F21FE862600957650 /* TezosKitExample.playground */,
 				77CE363421F7F327006ADABA /* Base58String */,
 				77CE380521FC7ED7006ADABA /* TezosKit */,
 				77CE35A321F7DC76006ADABA /* Tests */,
@@ -342,12 +344,12 @@
 			children = (
 				77CE388021FC7EED006ADABA /* Info.plist */,
 				77CE387F21FC7EED006ADABA /* TezosKit.h */,
+				77CE384421FC7ED8006ADABA /* Client */,
 				77CE380621FC7ED7006ADABA /* Operation */,
 				77CE381721FC7ED7006ADABA /* Cryptography */,
 				77CE381B21FC7ED7006ADABA /* Utils */,
 				77CE381E21FC7ED7006ADABA /* Models */,
 				77CE382721FC7ED7006ADABA /* RPC */,
-				77CE384421FC7ED8006ADABA /* Client */,
 			);
 			path = TezosKit;
 			sourceTree = SOURCE_ROOT;

--- a/TezosKit/Client/TezosClient.swift
+++ b/TezosKit/Client/TezosClient.swift
@@ -14,7 +14,7 @@ import Foundation
  * shared URLSession is used.
  *
  * The client can also be initialized with a custom DispatchQueue that all callbacks are called on. By default, the main
- * dispatch queue is used. 
+ * dispatch queue is used.
  *
  * RPCs
  * -------------
@@ -75,23 +75,6 @@ public class TezosClient {
 
   /** The queue that callbacks from requests will be made on. */
   private let callbackQueue: DispatchQueue
-
-  /**
-   * Initialize a new TezosClient using the default Node URL.
-   */
-  public convenience init() {
-    self.init(remoteNodeURL: type(of: self).defaultNodeURL)
-  }
-
-  /**
-   * Initialize a new TezosClient.
-   *
-   * - Parameter remoteNodeURL: The path to the remote node.
-   */
-  public convenience init(remoteNodeURL: URL) {
-    let urlSession = URLSession.shared
-    self.init(remoteNodeURL: remoteNodeURL, urlSession: urlSession)
-  }
 
   /**
    * Initialize a new TezosClient.

--- a/TezosKit/Client/TezosClient.swift
+++ b/TezosKit/Client/TezosClient.swift
@@ -557,7 +557,7 @@ public class TezosClient {
 
     let request = urlSession.dataTask(with: urlRequest as URLRequest) { [weak self] data, response, error in
       guard let self = self else {
-        return;
+        return
       }
 
       // Check if the response contained a 200 HTTP OK response. If not, then propagate an error.

--- a/TezosKit/Client/TezosClient.swift
+++ b/TezosKit/Client/TezosClient.swift
@@ -555,7 +555,11 @@ public class TezosClient {
       urlRequest.httpBody = payloadData
     }
 
-    let request = urlSession.dataTask(with: urlRequest as URLRequest) { [callbackQueue] data, response, error in
+    let request = urlSession.dataTask(with: urlRequest as URLRequest) { [weak self] data, response, error in
+      guard let self = self else {
+        return;
+      }
+
       // Check if the response contained a 200 HTTP OK response. If not, then propagate an error.
       if let httpResponse = response as? HTTPURLResponse,
         httpResponse.statusCode != 200 {
@@ -581,11 +585,11 @@ public class TezosClient {
         // Drop data and send our error to let subsequent handlers know something went wrong and to
         // give up.
         let error = TezosClientError(kind: errorKind, underlyingError: errorMessage)
-        rpc.handleResponse(data: nil, error: error, callbackQueue: callbackQueue)
+        rpc.handleResponse(data: nil, error: error, callbackQueue: self.callbackQueue)
         return
       }
 
-      rpc.handleResponse(data: data, error: error, callbackQueue: callbackQueue)
+      rpc.handleResponse(data: data, error: error, callbackQueue: self.callbackQueue)
     }
     request.resume()
   }

--- a/TezosKit/Client/TezosClient.swift
+++ b/TezosKit/Client/TezosClient.swift
@@ -10,7 +10,11 @@ import Foundation
  * The client is initialized with a node URL which points to a node who can receive JSON RPC
  * requests from this client. The default not is rpc.tezrpc.me, a public node provided by TezTech.
  *
- * The client also manages callbacks on a dispatch queue which can be managed by the client.
+ * The client can be initialized with a custom URLSession can be provided to manage network requests. By default, the
+ * shared URLSession is used.
+ *
+ * The client can also be initialized with a custom DispatchQueue that all callbacks are called on. By default, the main
+ * dispatch queue is used. 
  *
  * RPCs
  * -------------

--- a/TezosKit/RPC/TezosRPC.swift
+++ b/TezosKit/RPC/TezosRPC.swift
@@ -59,21 +59,29 @@ public class TezosRPC<T> {
    *
    * - Parameter data: Optional data returned from the network request.
    * - Parameter error: Optional error returned from the network request.
+   * - Parameter callbackQueue: A thread that the completion handler will be executed on, default is the main thread.
    */
-  public func handleResponse(data: Data?, error: Error?) {
+  public func handleResponse(data: Data?, error: Error?, callbackQueue: DispatchQueue = DispatchQueue.main) {
     if let error = error {
       let desc = error.localizedDescription
       let tezosClientError = TezosClientError(kind: .rpcError, underlyingError: desc)
-      completion(nil, tezosClientError)
+      callbackQueue.async {
+        self.completion(nil, tezosClientError)
+      }
       return
     }
 
     guard let data = data,
       let result = self.responseAdapterClass.parse(input: data) else {
       let tezosClientError = TezosClientError(kind: .unexpectedResponse, underlyingError: nil)
-      completion(nil, tezosClientError)
+      callbackQueue.async {
+        self.completion(nil, tezosClientError)
+      }
       return
     }
-    completion(result, nil)
+
+    callbackQueue.async {
+      self.completion(result, nil)
+    }
   }
 }


### PR DESCRIPTION
Manage callback queues.

I've tested this manually using the playground code. Really, TezosClient needs to get covered with tests but I don't currently have the resources to dedicate to that effort. 

Also, it may make sense to remove the logic from RPCs that performs the completion callback to avoid passing dispatch queues around and keep the RPC superclass succinct. I'll consider this in a future refactor once there's adequate testing to reduce regressions. 

Fixes #11 