### PR TITLE
Add promisekit extension for TezosNodeClient.

### DIFF
--- a/Extensions/PromiseKit/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNodeClient+Promises.swift
@@ -53,8 +53,8 @@ extension TezosNodeClient {
 
   /// Transact Tezos between accounts.
   /// - Parameters:
-  ///   - balance: The balance to send.
-  ///   - recipientAddress: The address which will receive the balance.
+  ///   - amount: The amount of Tez to send.
+  ///   - recipientAddress: The address which will receive the Tez.
   ///   - source: The address sending the balance.
   ///   - keys: The keys to use to sign the operation for the address.
   ///   - parameters: Optional parameters to include in the transaction if the call is being made to a smart contract.
@@ -89,8 +89,8 @@ extension TezosNodeClient {
   /// the keys to sign the operation for the address are the keys used to manage the TZ1 address.
   ///
   /// - Parameters:
-  ///   - recipientAddress: The address which will receive the balance.
-  ///   - source: The address sending the balance.
+  ///   - source: The address which will delegate.
+  ///   - delegate: The address which will receive the delegation.
   ///   - keys: The keys to use to sign the operation for the address.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
@@ -129,8 +129,7 @@ extension TezosNodeClient {
 
   /// Register an address as a delegate.
   /// - Parameters:
-  ///   - recipientAddress: The address which will receive the balance.
-  ///   - source: The address sending the balance.
+  ///   - delegate: The address registering as a delegate.
   ///   - keys: The keys to use to sign the operation for the address.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   /// - Returns: A promise which resolves to a string representing the transaction hash.

--- a/Extensions/PromiseKit/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNodeClient+Promises.swift
@@ -1,0 +1,259 @@
+// Copyright Keefer Taylor, 2019.
+
+import Foundation
+import PromiseKit
+
+/// Extension to TezosNodeClient which provides PromiseKit functionality.
+extension TezosNodeClient {
+  /// Retrieve data about the chain head.
+  public func getHead() -> Promise<[String: Any]> {
+    let rpc = GetChainHeadRPC()
+    return send(rpc)
+  }
+
+  /// Retrieve the balance of a given wallet.
+  public func getBalance(wallet: Wallet) -> Promise<Tez> {
+    return getBalance(address: wallet.address)
+  }
+
+  /// Retrieve the balance of a given address.
+  public func getBalance(address: String) -> Promise<Tez> {
+    let rpc = GetAddressBalanceRPC(address: address)
+    return send(rpc)
+  }
+
+  /// Retrieve the delegate of a given wallet.
+  public func getDelegate(wallet: Wallet) -> Promise<String> {
+    return getDelegate(address: wallet.address)
+  }
+
+  /// Retrieve the delegate of a given address.
+  public func getDelegate(address: String) -> Promise<String> {
+    let rpc = GetDelegateRPC(address: address)
+    return send(rpc)
+  }
+
+  /// Retrieve the hash of the block at the head of the chain.
+  public func getHeadHash() -> Promise<String> {
+    let rpc = GetChainHeadHashRPC()
+    return send(rpc)
+  }
+
+  /// Retrieve the address counter for the given address.
+  public func getAddressCounter(address: String) -> Promise<Int> {
+    let rpc = GetAddressCounterRPC(address: address)
+    return send(rpc)
+  }
+
+  /// Retrieve the address manager key for the given address.
+  public func getAddressManagerKey(address: String) -> Promise<[String: Any]> {
+    let rpc = GetAddressManagerKeyRPC(address: address)
+    return send(rpc)
+  }
+
+  /// Transact Tezos between accounts.
+  /// - Parameters:
+  ///   - balance: The balance to send.
+  ///   - recipientAddress: The address which will receive the balance.
+  ///   - source: The address sending the balance.
+  ///   - keys: The keys to use to sign the operation for the address.
+  ///   - parameters: Optional parameters to include in the transaction if the call is being made to a smart contract.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func send(
+    amount: Tez,
+    to recipientAddress: String,
+    from source: String,
+    keys: Keys,
+    parameters: [String: Any]? = nil,
+    operationFees: OperationFees? = nil
+  ) -> Promise<String> {
+    let transactionOperation = TransactionOperation(
+      amount: amount,
+      source: source,
+      destination: recipientAddress,
+      parameters: parameters,
+      operationFees: operationFees
+    )
+    return forgeSignPreapplyAndInjectOperation(
+      operation: transactionOperation,
+      source: source,
+      keys: keys
+    )
+  }
+
+  /// Delegate the balance of an originated account.
+  ///
+  /// Note that only KT1 accounts can delegate. TZ1 accounts are not able to delegate. This invariant
+  /// is not checked on an input to this methods. Thus, the source address must be a KT1 address and
+  /// the keys to sign the operation for the address are the keys used to manage the TZ1 address.
+  ///
+  /// - Parameters:
+  ///   - recipientAddress: The address which will receive the balance.
+  ///   - source: The address sending the balance.
+  ///   - keys: The keys to use to sign the operation for the address.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func delegate(
+    from source: String,
+    to delegate: String,
+    keys: Keys,
+    operationFees: OperationFees? = nil
+  ) -> Promise<String> {
+    let delegationOperation = DelegationOperation(source: source, to: delegate, operationFees: operationFees)
+    return forgeSignPreapplyAndInjectOperation(
+      operation: delegationOperation,
+      source: source,
+      keys: keys
+    )
+  }
+
+  /// Clear the delegate of an originated account.
+  /// - Parameters:
+  ///   - source: The address which is removing the delegate.
+  ///   - keys: The keys to use to sign the operation for the address.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func undelegate(
+    from source: String,
+    keys: Keys,
+    operationFees: OperationFees? = nil
+  ) -> Promise<String> {
+    let undelegateOperatoin = UndelegateOperation(source: source, operationFees: operationFees)
+    return forgeSignPreapplyAndInjectOperation(
+      operation: undelegateOperatoin,
+      source: source,
+      keys: keys
+    )
+  }
+
+  /// Register an address as a delegate.
+  /// - Parameters:
+  ///   - recipientAddress: The address which will receive the balance.
+  ///   - source: The address sending the balance.
+  ///   - keys: The keys to use to sign the operation for the address.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func registerDelegate(
+    delegate: String,
+    keys: Keys,
+    operationFees: OperationFees? = nil
+  ) -> Promise<String> {
+    let registerDelegateOperation = RegisterDelegateOperation(delegate: delegate, operationFees: operationFees)
+    return forgeSignPreapplyAndInjectOperation(
+      operation: registerDelegateOperation,
+      source: delegate,
+      keys: keys
+    )
+  }
+
+  /// Originate a new account from the given account.
+  /// - Parameters:
+  ///   - managerAddress: The address which will manage the new account.
+  ///   - keys: The keys to use to sign the operation for the address.
+  ///   - contractCode: Optional code to associate with the originated contract.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func originateAccount(
+    managerAddress: String,
+    keys: Keys,
+    contractCode: ContractCode? = nil,
+    operationFees: OperationFees? = nil
+  ) -> Promise<String> {
+    let originateAccountOperation =
+      OriginateAccountOperation(address: managerAddress, contractCode: contractCode, operationFees: operationFees)
+    return forgeSignPreapplyAndInjectOperation(
+      operation: originateAccountOperation,
+      source: managerAddress,
+      keys: keys
+    )
+  }
+
+  /// Returns the code associated with the address as a NSDictionary.
+  /// - Parameter address: The address of the contract to load.
+  public func getAddressCode(address: String) -> Promise<ContractCode> {
+    let rpc = GetAddressCodeRPC(address: address)
+    return send(rpc)
+  }
+
+  /// Retrieve ballots cast so far during a voting period.
+  public func getBallotsList() -> Promise<[[String: Any]]> {
+    let rpc = GetBallotsListRPC()
+    return send(rpc)
+  }
+
+  ///Retrieve the expected quorum.
+  public func getExpectedQuorum() -> Promise<Int> {
+    let rpc = GetExpectedQuorumRPC()
+    return send(rpc)
+  }
+
+  /// Retrieve the current period kind for voting.
+  public func getCurrentPeriodKind() -> Promise<PeriodKind> {
+    let rpc = GetCurrentPeriodKindRPC()
+    return send(rpc)
+  }
+
+  /// Retrieve the sum of ballots cast so far during a voting period.
+  public func getBallots() -> Promise<[String: Any]> {
+    let rpc = GetBallotsRPC()
+    return send(rpc)
+  }
+
+  /// Retrieve a list of proposals with number of supporters.
+  public func getProposalsList() -> Promise<[[String: Any]]> {
+    let rpc = GetProposalsListRPC()
+    return send(rpc)
+  }
+
+  /// Retrieve the current proposal under evaluation.
+  public func getProposalUnderEvaluation() -> Promise<String> {
+    let rpc = GetProposalUnderEvaluationRPC()
+    return send(rpc)
+  }
+
+  /// Retrieve a list of delegates with their voting weight, in number of rolls.
+  public func getVotingDelegateRights() -> Promise<[[String: Any]]> {
+    let rpc = GetVotingDelegateRightsRPC()
+    return send(rpc)
+  }
+
+  /// Forge, sign, preapply and then inject a single operation.
+  /// - Parameters:
+  ///   - operation: The operation which will be forged.
+  ///   - source: The address performing the operation.
+  ///   - keys: The keys to use to sign the operation for the address.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func forgeSignPreapplyAndInjectOperation(
+    operation: Operation,
+    source: String,
+    keys: Keys
+  ) -> Promise<String> {
+    return forgeSignPreapplyAndInjectOperations(
+      operations: [operation],
+      source: source,
+      keys: keys
+    )
+  }
+
+  /// Forge, sign, preapply and then inject a single operation.
+  ///
+  /// Operations are processed in the order they are placed in the operation array.
+  ///
+  /// - Parameters:
+  ///   - operations: An array of operations that will be forged.
+  ///   - source: The address performing the operation.
+  ///   - keys: The keys to use to sign the operation for the address.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func forgeSignPreapplyAndInjectOperations(
+    operations: [Operation],
+    source: String,
+    keys: Keys
+  ) -> Promise<String> {
+    return Promise { seal in
+      forgeSignPreapplyAndInjectOperations(operations: operations, source: source, keys: keys) { result, error in
+        seal.resolve(result, error)
+      }
+    }
+  }
+}

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		7774780B2222281B0010BA4D /* TezosKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CE359621F7DC76006ADABA /* TezosKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		7774780C222228590010BA4D /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
 		7774780F222228E50010BA4D /* PromiseKit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7774780E222228E50010BA4D /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		77B1EADE222496B500EA4FCE /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */; };
 		77CE36E021F7F49F006ADABA /* IntegerResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36B921F7F49C006ADABA /* IntegerResponseAdapterTest.swift */; };
 		77CE36E121F7F49F006ADABA /* RevealOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BA21F7F49C006ADABA /* RevealOperationTest.swift */; };
 		77CE36E221F7F49F006ADABA /* ForgeOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BB21F7F49C006ADABA /* ForgeOperationRPCTest.swift */; };
@@ -144,6 +145,7 @@
 		7774780422221DE50010BA4D /* AbstractClientTest+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractClientTest+Promises.swift"; sourceTree = "<group>"; };
 		7774780E222228E50010BA4D /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromiseKit.framework; path = Carthage/Build/iOS/PromiseKit.framework; sourceTree = "<group>"; };
 		7791E60F21FE862600957650 /* TezosKitExample.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = TezosKitExample.playground; path = Examples/TezosKitExample.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeClient+Promises.swift"; sourceTree = "<group>"; };
 		77CE359621F7DC76006ADABA /* TezosKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TezosKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE359F21F7DC76006ADABA /* TezosKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TezosKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE35A621F7DC76006ADABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -438,6 +440,7 @@
 			isa = PBXGroup;
 			children = (
 				77F4D26E22220C9600D34B01 /* AbstractClient+Promises.swift */,
+				77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */,
 			);
 			path = PromiseKit;
 			sourceTree = "<group>";
@@ -692,6 +695,7 @@
 				77CE385921FC7ED8006ADABA /* Tez.swift in Sources */,
 				77CE385F21FC7ED8006ADABA /* ContractCode.swift in Sources */,
 				77CE386821FC7ED8006ADABA /* ResponseAdapter.swift in Sources */,
+				77B1EADE222496B500EA4FCE /* TezosNodeClient+Promises.swift in Sources */,
 				77CE386221FC7ED8006ADABA /* GetChainHeadHashRPC.swift in Sources */,
 				77CE387821FC7ED8006ADABA /* GetBallotsListRPC.swift in Sources */,
 				77CE386921FC7ED8006ADABA /* JSONDictionaryResponseAdapter.swift in Sources */,

--- a/TezosKit/Client/TezosNodeClient.swift
+++ b/TezosKit/Client/TezosNodeClient.swift
@@ -134,19 +134,15 @@ public class TezosNodeClient: AbstractClient {
     send(rpc: rpc, completion: completion)
   }
 
-  /**
-   * Transact Tezos between accounts.
-   *
-   * - Parameter balance: The balance to send.
-   * - Parameter recipientAddress: The address which will receive the balance.
-   * - Parameter source: The address sending the balance.
-   * - Parameter keys: The keys to use to sign the operation for the address.
-   * - Parameter parameters: Optional parameters to include in the transaction if the call is being made to a smart
-   *             contract.
-   * - Parameter operationFees: OperationFees for the transaction. If nil, default fees are used.
-   * - Parameter completion: A completion block which will be called with a string representing the
-   *        transaction ID hash if the operation was successful.
-   */
+  /// Transact Tezos between accounts.
+  /// - Parameters:
+  ///   - amount: The amount of Tez to send.
+  ///   - recipientAddress: The address which will receive the Tez.
+  ///   - source: The address sending the balance.
+  ///   - keys: The keys to use to sign the operation for the address.
+  ///   - parameters: Optional parameters to include in the transaction if the call is being made to a smart contract.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - completion: A completion block called with an optional transaction hash and error.
   public func send(
     amount: Tez,
     to recipientAddress: String,
@@ -171,20 +167,18 @@ public class TezosNodeClient: AbstractClient {
     )
   }
 
-  /**
-   * Delegate the balance of an originated account.
-   *
-   * Note that only KT1 accounts can delegate. TZ1 accounts are not able to delegate. This invariant
-   * is not checked on an input to this methods. Thus, the source address must be a KT1 address and
-   * the keys to sign the operation for the address are the keys used to manage the TZ1 address.
-   *
-   * - Parameter recipientAddress: The address which will receive the balance.
-   * - Parameter source: The address sending the balance.
-   * - Parameter keys: The keys to use to sign the operation for the address.
-   * - Parameter operationFees: OperationFees for the transaction. If nil, default fees are used.
-   * - Parameter completion: A completion block which will be called with a string representing the transaction ID hash
-   *             if the operation was successful.
-   */
+  /// Delegate the balance of an originated account.
+  ///
+  /// Note that only KT1 accounts can delegate. TZ1 accounts are not able to delegate. This invariant
+  /// is not checked on an input to this methods. Thus, the source address must be a KT1 address and
+  /// the keys to sign the operation for the address are the keys used to manage the TZ1 address.
+  ///
+  /// - Parameters:
+  ///   - source: The address which will delegate.
+  ///   - delegate: The address which will receive the delegation.
+  ///   - keys: The keys to use to sign the operation for the address.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - completion: A completion block called with an optional transaction hash and error.
   public func delegate(
     from source: String,
     to delegate: String,
@@ -225,16 +219,12 @@ public class TezosNodeClient: AbstractClient {
     )
   }
 
-  /**
-   * Register an address as a delegate.
-   *
-   * - Parameter recipientAddress: The address which will receive the balance.
-   * - Parameter source: The address sending the balance.
-   * - Parameter keys: The keys to use to sign the operation for the address.
-   * - Parameter operationFees: OperationFees for the transaction. If nil, default fees are used.
-   * - Parameter completion: A completion block which will be called with a string representing the transaction ID hash
-   *             if the operation was successful.
-   */
+  /// Register an address as a delegate.
+  /// - Parameters:
+  ///   - delegate: The address registering as a delegate.
+  ///   - keys: The keys to use to sign the operation for the address.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - completion: A completion block called with an optional transaction hash and error.
   public func registerDelegate(
     delegate: String,
     keys: Keys,

--- a/TezosKit/Client/TezosNodeClient.swift
+++ b/TezosKit/Client/TezosNodeClient.swift
@@ -291,7 +291,7 @@ public class TezosNodeClient: AbstractClient {
    * Retrieve ballots cast so far during a voting period.
    */
   public func getBallotsList(completion: @escaping ([[String: Any]]?, Error?) -> Void) {
-    let rpc = GetBallotsListRPC(completion: completion)
+    let rpc = GetBallotsListRPC()
     send(rpc: rpc, completion: completion)
   }
 

--- a/TezosKit/RPC/GetBallotsListRPC.swift
+++ b/TezosKit/RPC/GetBallotsListRPC.swift
@@ -6,7 +6,7 @@ import Foundation
  * An RPC which will retrieve ballots cast so far during a voting period.
  */
 public class GetBallotsListRPC: RPC<[[String: Any]]> {
-  public init(completion: @escaping ([[String: Any]]?, Error?) -> Void) {
+  public init() {
     let endpoint = "chains/main/blocks/head/votes/ballot_list"
     super.init(endpoint: endpoint, responseAdapterClass: JSONArrayResponseAdapter.self)
   }


### PR DESCRIPTION
Adds Promise methods for TezosNodeClient.

Also cleans up an issue where there was an unused `completion` argument passed to an RPC.