### PR TITLE
Tests for TezosNodeClient

### DIFF
--- a/Tests/TezosKit/AbstractClientTest.swift
+++ b/Tests/TezosKit/AbstractClientTest.swift
@@ -3,49 +3,6 @@
 @testable import TezosKit
 import XCTest
 
-/// A fake URLSession that will return data tasks which will call completion handlers with the given parameters.
-public class FakeURLSession: URLSession {
-  public var urlResponse: URLResponse?
-  public var data: Data?
-  public var error: Error?
-
-  public override func dataTask(
-    with request: URLRequest,
-    completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
-  ) -> URLSessionDataTask {
-    return FakeURLSessionDataTask(
-      urlResponse: urlResponse,
-      data: data,
-      error: error,
-      completionHandler: completionHandler
-    )
-  }
-}
-
-/// A fake data task that will immediately call completion.
-public class FakeURLSessionDataTask: URLSessionDataTask {
-  private let urlResponse: URLResponse?
-  private let data: Data?
-  private let fakedError: Error?
-  private let completionHandler: (Data?, URLResponse?, Error?) -> Void
-
-  public init(
-    urlResponse: URLResponse?,
-    data: Data?,
-    error: Error?,
-    completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
-    ) {
-    self.urlResponse = urlResponse
-    self.data = data
-    self.fakedError = error
-    self.completionHandler = completionHandler
-  }
-
-  public override func resume() {
-    completionHandler(data, urlResponse, fakedError)
-  }
-}
-
 class AbstractClientTest: XCTestCase {
   public var abstractClient: AbstractClient?
 

--- a/Tests/TezosKit/Helpers/FakeURLSession.swift
+++ b/Tests/TezosKit/Helpers/FakeURLSession.swift
@@ -1,0 +1,22 @@
+// Copyright Keefer Taylor, 2019.
+
+import Foundation
+
+/// A fake URLSession that will return data tasks which will call completion handlers with the given parameters.
+public class FakeURLSession: URLSession {
+  public var urlResponse: URLResponse?
+  public var data: Data?
+  public var error: Error?
+
+  public override func dataTask(
+    with request: URLRequest,
+    completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) -> URLSessionDataTask {
+    return FakeURLSessionDataTask(
+      urlResponse: urlResponse,
+      data: data,
+      error: error,
+      completionHandler: completionHandler
+    )
+  }
+}

--- a/Tests/TezosKit/Helpers/FakeURLSessionDataTask.swift
+++ b/Tests/TezosKit/Helpers/FakeURLSessionDataTask.swift
@@ -1,0 +1,26 @@
+// Copyright Keefer Taylor, 2019. 
+import Foundation
+
+/// A fake data task that will immediately call completion.
+public class FakeURLSessionDataTask: URLSessionDataTask {
+  private let urlResponse: URLResponse?
+  private let data: Data?
+  private let fakedError: Error?
+  private let completionHandler: (Data?, URLResponse?, Error?) -> Void
+
+  public init(
+    urlResponse: URLResponse?,
+    data: Data?,
+    error: Error?,
+    completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void
+    ) {
+    self.urlResponse = urlResponse
+    self.data = data
+    self.fakedError = error
+    self.completionHandler = completionHandler
+  }
+
+  public override func resume() {
+    completionHandler(data, urlResponse, fakedError)
+  }
+}

--- a/Tests/TezosKit/TezosNodeClientTests.swift
+++ b/Tests/TezosKit/TezosNodeClientTests.swift
@@ -1,0 +1,31 @@
+// Copyright Keefer Taylor, 2019.
+
+import TezosKit
+import XCTest
+
+class TezosNodeClientTests: XCTestCase {
+  public static let timeout = 10.0
+
+  public var nodeClient: TezosNodeClient?
+  public let fakeURLSession = FakeURLSession()
+
+  public override func setUp() {
+    super.setUp()
+    nodeClient = TezosNodeClient(urlSession: fakeURLSession)
+  }
+
+  public func testGetHeadHash() {
+    let testHeadHash = "BM3e24i3NhYyzfZ1Rb7Lo5KZw4vV2bZWSx93TsVjxcKdaHDp6yk"
+    fakeURLSession.data = testHeadHash.data(using: .utf8)
+
+    let expectation = XCTestExpectation(description: "completion called")
+    nodeClient?.getHeadHash { hash, error in
+      XCTAssertEqual(hash, testHeadHash)
+      XCTAssertNil(error)
+
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: TezosNodeClientTests.timeout)
+  }
+}

--- a/Tests/TezosKit/TezosNodeClientTests.swift
+++ b/Tests/TezosKit/TezosNodeClientTests.swift
@@ -30,6 +30,7 @@ class TezosNodeClientTests: XCTestCase {
   }
 
   public func testGetAddressBalance() {
+    // TODO: Drop leading zero.
     let testAddressBalance = "0277592"
     fakeURLSession.data = testAddressBalance.data(using: .utf8)
 

--- a/Tests/TezosKit/TezosNodeClientTests.swift
+++ b/Tests/TezosKit/TezosNodeClientTests.swift
@@ -28,4 +28,19 @@ class TezosNodeClientTests: XCTestCase {
 
     wait(for: [expectation], timeout: TezosNodeClientTests.timeout)
   }
+
+  public func testGetAddressBalance() {
+    let testAddressBalance = "0277592"
+    fakeURLSession.data = testAddressBalance.data(using: .utf8)
+
+    let expectation = XCTestExpectation(description: "completion called")
+    nodeClient?.getBalance(address: "tz1sNXT8yZCwTss2YcoFi3qbXvTZiCojx833") { balance, error in
+      XCTAssertEqual(balance?.rpcRepresentation, testAddressBalance)
+      XCTAssertNil(error)
+
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: TezosNodeClientTests.timeout)
+  }
 }

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		7774780B2222281B0010BA4D /* TezosKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CE359621F7DC76006ADABA /* TezosKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		7774780C222228590010BA4D /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
 		7774780F222228E50010BA4D /* PromiseKit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7774780E222228E50010BA4D /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		77B1EAE12224A25600EA4FCE /* FakeURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EAE02224A25600EA4FCE /* FakeURLSession.swift */; };
+		77B1EAE32224A28D00EA4FCE /* FakeURLSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EAE22224A28D00EA4FCE /* FakeURLSessionDataTask.swift */; };
 		77CE36E021F7F49F006ADABA /* IntegerResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36B921F7F49C006ADABA /* IntegerResponseAdapterTest.swift */; };
 		77CE36E121F7F49F006ADABA /* RevealOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BA21F7F49C006ADABA /* RevealOperationTest.swift */; };
 		77CE36E221F7F49F006ADABA /* ForgeOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BB21F7F49C006ADABA /* ForgeOperationRPCTest.swift */; };
@@ -144,6 +146,8 @@
 		7774780422221DE50010BA4D /* AbstractClientTest+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractClientTest+Promises.swift"; sourceTree = "<group>"; };
 		7774780E222228E50010BA4D /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromiseKit.framework; path = Carthage/Build/iOS/PromiseKit.framework; sourceTree = "<group>"; };
 		7791E60F21FE862600957650 /* TezosKitExample.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = TezosKitExample.playground; path = Examples/TezosKitExample.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		77B1EAE02224A25600EA4FCE /* FakeURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeURLSession.swift; sourceTree = "<group>"; };
+		77B1EAE22224A28D00EA4FCE /* FakeURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeURLSessionDataTask.swift; sourceTree = "<group>"; };
 		77CE359621F7DC76006ADABA /* TezosKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TezosKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE359F21F7DC76006ADABA /* TezosKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TezosKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE35A621F7DC76006ADABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -273,6 +277,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		77B1EADF2224A24000EA4FCE /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				77B1EAE02224A25600EA4FCE /* FakeURLSession.swift */,
+				77B1EAE22224A28D00EA4FCE /* FakeURLSessionDataTask.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		77CE358C21F7DC76006ADABA = {
 			isa = PBXGroup;
 			children = (
@@ -445,6 +458,7 @@
 		77F4D27322221CCE00D34B01 /* TezosKit */ = {
 			isa = PBXGroup;
 			children = (
+				77B1EADF2224A24000EA4FCE /* Helpers */,
 				77F4D267221CD44100D34B01 /* AbstractClientTest.swift */,
 				77F4D263221CB53900D34B01 /* RPCResponseHandlerTest.swift */,
 				77CE36C221F7F49C006ADABA /* AbstractOperationTest.swift */,
@@ -754,10 +768,12 @@
 				77CE36E221F7F49F006ADABA /* ForgeOperationRPCTest.swift in Sources */,
 				77CE36F721F7F49F006ADABA /* WalletTests.swift in Sources */,
 				77F4D268221CD44100D34B01 /* AbstractClientTest.swift in Sources */,
+				77B1EAE32224A28D00EA4FCE /* FakeURLSessionDataTask.swift in Sources */,
 				77CE36E721F7F49F006ADABA /* OriginateAccountOperation.swift in Sources */,
 				77CE36E521F7F49F006ADABA /* RPCTest.swift in Sources */,
 				77CE36E821F7F49F006ADABA /* KeysTests.swift in Sources */,
 				77CE370621F7F49F006ADABA /* TezResponseAdapterTest.swift in Sources */,
+				77B1EAE12224A25600EA4FCE /* FakeURLSession.swift in Sources */,
 				77CE370521F7F49F006ADABA /* DelegationOperationTest.swift in Sources */,
 				77CE36FC21F7F49F006ADABA /* GetProposalsListRPCTest.swift in Sources */,
 				77CE370021F7F49F006ADABA /* GetAddressCounterRPCTest.swift in Sources */,

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		7774780F222228E50010BA4D /* PromiseKit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7774780E222228E50010BA4D /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		77B1EAE12224A25600EA4FCE /* FakeURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EAE02224A25600EA4FCE /* FakeURLSession.swift */; };
 		77B1EAE32224A28D00EA4FCE /* FakeURLSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EAE22224A28D00EA4FCE /* FakeURLSessionDataTask.swift */; };
+		77B1EAE52224A3A100EA4FCE /* TezosNodeClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EAE42224A3A100EA4FCE /* TezosNodeClientTests.swift */; };
 		77CE36E021F7F49F006ADABA /* IntegerResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36B921F7F49C006ADABA /* IntegerResponseAdapterTest.swift */; };
 		77CE36E121F7F49F006ADABA /* RevealOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BA21F7F49C006ADABA /* RevealOperationTest.swift */; };
 		77CE36E221F7F49F006ADABA /* ForgeOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BB21F7F49C006ADABA /* ForgeOperationRPCTest.swift */; };
@@ -148,6 +149,7 @@
 		7791E60F21FE862600957650 /* TezosKitExample.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = TezosKitExample.playground; path = Examples/TezosKitExample.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		77B1EAE02224A25600EA4FCE /* FakeURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeURLSession.swift; sourceTree = "<group>"; };
 		77B1EAE22224A28D00EA4FCE /* FakeURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeURLSessionDataTask.swift; sourceTree = "<group>"; };
+		77B1EAE42224A3A100EA4FCE /* TezosNodeClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosNodeClientTests.swift; sourceTree = "<group>"; };
 		77CE359621F7DC76006ADABA /* TezosKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TezosKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE359F21F7DC76006ADABA /* TezosKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TezosKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE35A621F7DC76006ADABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -460,6 +462,7 @@
 			children = (
 				77B1EADF2224A24000EA4FCE /* Helpers */,
 				77F4D267221CD44100D34B01 /* AbstractClientTest.swift */,
+				77B1EAE42224A3A100EA4FCE /* TezosNodeClientTests.swift */,
 				77F4D263221CB53900D34B01 /* RPCResponseHandlerTest.swift */,
 				77CE36C221F7F49C006ADABA /* AbstractOperationTest.swift */,
 				77CE36DE21F7F49E006ADABA /* DelegationOperationTest.swift */,
@@ -743,6 +746,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				77B1EAE52224A3A100EA4FCE /* TezosNodeClientTests.swift in Sources */,
 				77CE36F821F7F49F006ADABA /* StringResponseAdapterTest.swift in Sources */,
 				77CE36FB21F7F49F006ADABA /* MnemonicUtilsTest.swift in Sources */,
 				77CE36E621F7F49F006ADABA /* TransactionOperationTest.swift in Sources */,


### PR DESCRIPTION
Uses FakeURLSession to mock expected responses from the server and ensure results are returned correctly. 