### PR TITLE
Migrate to Swift's `Result` type

### DIFF
--- a/Extensions/PromiseKit/AbstractClient+Promises.swift
+++ b/Extensions/PromiseKit/AbstractClient+Promises.swift
@@ -12,8 +12,13 @@ extension AbstractClient {
   /// - Returns: A promise which will resolve to the result of the RPC.
   public func send<T>(_ rpc: RPC<T>) -> Promise<T> {
     return Promise { seal in
-      send(rpc) { result, error in
-        seal.resolve(result, error)
+      send(rpc) { result in
+        switch result {
+        case .success(let data):
+            seal.fulfill(data)
+        case .failure(let error):
+            seal.reject(error)
+        }
       }
     }
   }

--- a/Extensions/PromiseKit/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNodeClient+Promises.swift
@@ -250,8 +250,13 @@ extension TezosNodeClient {
     keys: Keys
   ) -> Promise<String> {
     return Promise { seal in
-      forgeSignPreapplyAndInject(operations, source: source, keys: keys) { result, error in
-        seal.resolve(result, error)
+      forgeSignPreapplyAndInject(operations, source: source, keys: keys) { result in
+        switch result {
+        case .success(let data):
+          seal.fulfill(data)
+        case .failure(let error):
+          seal.reject(error)
+        }
       }
     }
   }
@@ -263,8 +268,13 @@ extension TezosNodeClient {
   /// - Returns: A promise which resolves to the result of running the operation.
   public func runOperation(_ operation: Operation, from wallet: Wallet) -> Promise<[String: Any]> {
     return Promise { seal in
-      runOperation(operation, from: wallet) { result, error in
-        seal.resolve(result, error)
+      runOperation(operation, from: wallet) { result in
+        switch result {
+        case .success(let data):
+            seal.fulfill(data)
+        case .failure(let error):
+            seal.reject(error)
+        }
       }
     }
   }

--- a/Tests/Extensions/PromiseKit/AbstractClientTest+Promises.swift
+++ b/Tests/Extensions/PromiseKit/AbstractClientTest+Promises.swift
@@ -10,7 +10,7 @@ extension AbstractClientTest {
 
     // RPC endpoint will not resolve to a valid URL.
     let rpc = RPC(endpoint: "/    /\"test", responseAdapterClass: StringResponseAdapter.self)
-    abstractClient?.send(rpc) { (_, _) in
+    abstractClient?.send(rpc) { _ in
       if #available(iOS 10, OSX 10.12, *) {
         dispatchPrecondition(condition: .onQueue(self.callbackQueue))
       }
@@ -23,7 +23,7 @@ extension AbstractClientTest {
   public func testCallbackOnCorrectQueue_promises() {
     let expectation = XCTestExpectation(description: "Promise is resolved")
     let rpc = RPC(endpoint: "/test", responseAdapterClass: StringResponseAdapter.self)
-    abstractClient?.send(rpc) { (_, _) in
+    abstractClient?.send(rpc) { _ in
       if #available(iOS 10, OSX 10.12, *) {
         dispatchPrecondition(condition: .onQueue(self.callbackQueue))
       }

--- a/Tests/TezosKit/AbstractClientTest.swift
+++ b/Tests/TezosKit/AbstractClientTest.swift
@@ -68,7 +68,7 @@ class AbstractClientTest: XCTestCase {
 
     // RPC endpoint will not resolve to a valid URL.
     let rpc = RPC(endpoint: "/    /\"test", responseAdapterClass: StringResponseAdapter.self)
-    abstractClient?.send(rpc) { (_, _) in
+    abstractClient?.send(rpc) { _ in
       if #available(iOS 10, OSX 10.12, *) {
         dispatchPrecondition(condition: .onQueue(self.callbackQueue))
       }
@@ -81,7 +81,7 @@ class AbstractClientTest: XCTestCase {
   public func testCallbackOnCorrectQueue() {
     let expectation = XCTestExpectation(description: "Completion is Called")
     let rpc = RPC(endpoint: "/test", responseAdapterClass: StringResponseAdapter.self)
-    abstractClient?.send(rpc) { (_, _) in
+    abstractClient?.send(rpc) { _ in
       if #available(iOS 10, OSX 10.12, *) {
         dispatchPrecondition(condition: .onQueue(self.callbackQueue))
       }
@@ -96,11 +96,13 @@ class AbstractClientTest: XCTestCase {
 
     // RPC endpoint will not resolve to a valid URL.
     let rpc = RPC(endpoint: "/    /\"test", responseAdapterClass: StringResponseAdapter.self)
-    abstractClient?.send(rpc) { (result, error) in
-      XCTAssertNil(result)
-      XCTAssertNotNil(error)
-
-      expectation.fulfill()
+    abstractClient?.send(rpc) { result in
+      switch result {
+      case .failure:
+        expectation.fulfill()
+      case .success:
+        XCTFail()
+      }
     }
 
     wait(for: [expectation], timeout: 10)
@@ -118,11 +120,13 @@ class AbstractClientTest: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Completion is Called")
     let rpc = RPC(endpoint: "/test", responseAdapterClass: StringResponseAdapter.self)
-    abstractClient?.send(rpc) { (result, error) in
-      XCTAssertNil(result)
-      XCTAssertNotNil(error)
-
-      expectation.fulfill()
+    abstractClient?.send(rpc) { result in
+      switch result {
+      case .failure:
+        expectation.fulfill()
+      case .success:
+        XCTFail()
+      }
     }
 
     wait(for: [expectation], timeout: 10)
@@ -141,11 +145,13 @@ class AbstractClientTest: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Completion is Called")
     let rpc = RPC(endpoint: "/test", responseAdapterClass: StringResponseAdapter.self)
-    abstractClient?.send(rpc) { (result, error) in
-      XCTAssertNil(result)
-      XCTAssertNotNil(error)
-
-      expectation.fulfill()
+    abstractClient?.send(rpc) { result in
+      switch result {
+      case .failure:
+        expectation.fulfill()
+      case .success:
+        XCTFail()
+      }
     }
 
     wait(for: [expectation], timeout: 10)
@@ -162,11 +168,13 @@ class AbstractClientTest: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Completion is Called")
     let rpc = RPC(endpoint: "/test", responseAdapterClass: StringResponseAdapter.self)
-    abstractClient?.send(rpc) { (result, error) in
-      XCTAssertNil(result)
-      XCTAssertNotNil(error)
-
-      expectation.fulfill()
+    abstractClient?.send(rpc) { result in
+      switch result {
+      case .failure:
+        expectation.fulfill()
+      case .success:
+        XCTFail()
+      }
     }
 
     wait(for: [expectation], timeout: 10)
@@ -183,11 +191,13 @@ class AbstractClientTest: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Completion is Called")
     let rpc = RPC(endpoint: "/test", responseAdapterClass: IntegerResponseAdapter.self)
-    abstractClient?.send(rpc) { (result, error) in
-      XCTAssertNil(result)
-      XCTAssertNotNil(error)
-
-      expectation.fulfill()
+    abstractClient?.send(rpc) { result in
+      switch result {
+      case .failure:
+        expectation.fulfill()
+      case .success:
+        XCTFail()
+      }
     }
 
     wait(for: [expectation], timeout: 10)
@@ -206,12 +216,14 @@ class AbstractClientTest: XCTestCase {
 
     let expectation = XCTestExpectation(description: "Completion is Called")
     let rpc = RPC(endpoint: "/test", responseAdapterClass: StringResponseAdapter.self)
-    abstractClient?.send(rpc) { (result, error) in
-      XCTAssertNotNil(result)
-      XCTAssertEqual(result, expectedString)
-      XCTAssertNil(error)
-
-      expectation.fulfill()
+    abstractClient?.send(rpc) { result in
+      switch result {
+      case .failure:
+        XCTFail()
+      case .success(let data):
+        XCTAssertEqual(data, expectedString)
+        expectation.fulfill()
+      }
     }
 
     wait(for: [expectation], timeout: 10)

--- a/Tests/TezosKit/RPCResponseHandlerTest.swift
+++ b/Tests/TezosKit/RPCResponseHandlerTest.swift
@@ -36,143 +36,128 @@ class RPCResponseHandlerTest: XCTestCase {
 
   public func testHandleResponseWithHTTP400() {
     let response = httpResponse(with: 400)
-    let (result, error) = RPCResponseHandlerTest.responseHandler.handleResponse(
+    let result = RPCResponseHandlerTest.responseHandler.handleResponse(
       response: response,
       data: testErrorStringData,
       error: TestError.testError,
       responseAdapterClass: StringResponseAdapter.self
     )
 
-    XCTAssertNil(result)
-    XCTAssertNotNil(error)
-
-    guard let tezosKitError = error as? TezosKitError else {
+    switch result {
+    case .failure(let tezosKitError):
+      XCTAssertEqual(tezosKitError.kind, .unexpectedRequestFormat)
+      XCTAssertEqual(tezosKitError.underlyingError, RPCResponseHandlerTest.testErrorString)
+    case .success:
       XCTFail()
-      return
     }
-
-    XCTAssertEqual(tezosKitError.kind, .unexpectedRequestFormat)
-    XCTAssertEqual(tezosKitError.underlyingError, RPCResponseHandlerTest.testErrorString)
   }
 
   public func testHandleResponseWithHTTP500() {
     let response = httpResponse(with: 500)
-    let (result, error) = RPCResponseHandlerTest.responseHandler.handleResponse(
+    let result = RPCResponseHandlerTest.responseHandler.handleResponse(
       response: response,
       data: testErrorStringData,
       error: TestError.testError,
       responseAdapterClass: StringResponseAdapter.self
     )
 
-    XCTAssertNil(result)
-    XCTAssertNotNil(error)
-
-    guard let tezosKitError = error as? TezosKitError else {
+    switch result {
+    case .failure(let tezosKitError):
+      XCTAssertEqual(tezosKitError.kind, .unexpectedResponse)
+      XCTAssertEqual(tezosKitError.underlyingError, RPCResponseHandlerTest.testErrorString)
+    case .success:
       XCTFail()
-      return
     }
-
-    XCTAssertEqual(tezosKitError.kind, .unexpectedResponse)
-    XCTAssertEqual(tezosKitError.underlyingError, RPCResponseHandlerTest.testErrorString)
   }
 
   public func testHandleResponseWithHTTPInvalid() {
     let response = httpResponse(with: 9_000)
-    let (result, error) = RPCResponseHandlerTest.responseHandler.handleResponse(
+    let result = RPCResponseHandlerTest.responseHandler.handleResponse(
       response: response,
       data: testErrorStringData,
       error: TestError.testError,
       responseAdapterClass: StringResponseAdapter.self
     )
 
-    XCTAssertNil(result)
-    XCTAssertNotNil(error)
-
-    guard let tezosKitError = error as? TezosKitError else {
+    switch result {
+    case .failure(let tezosKitError):
+      XCTAssertEqual(tezosKitError.kind, .unknown)
+      XCTAssertEqual(tezosKitError.underlyingError, RPCResponseHandlerTest.testErrorString)
+    case .success:
       XCTFail()
-      return
     }
-
-    XCTAssertEqual(tezosKitError.kind, .unknown)
-    XCTAssertEqual(tezosKitError.underlyingError, RPCResponseHandlerTest.testErrorString)
   }
 
   public func testHandleResponseWithHTTP200AndError() {
     let response = httpResponse(with: 200)
     let testError = TestError.testError
-    let (result, error) = RPCResponseHandlerTest.responseHandler.handleResponse(
+    let result = RPCResponseHandlerTest.responseHandler.handleResponse(
       response: response,
       data: testParsedStringData,
       error: testError,
       responseAdapterClass: StringResponseAdapter.self
     )
 
-    XCTAssertNotNil(error)
-    XCTAssertNil(result)
-
-    guard let tezosKitError = error as? TezosKitError else {
+    switch result {
+    case .failure(let tezosKitError):
+      XCTAssertEqual(tezosKitError.kind, .rpcError)
+      XCTAssertEqual(tezosKitError.underlyingError, testError.localizedDescription)
+    case .success:
       XCTFail()
-      return
     }
-
-    XCTAssertEqual(tezosKitError.kind, .rpcError)
-    XCTAssertEqual(tezosKitError.underlyingError, testError.localizedDescription)
   }
 
   public func testHandleResponseWithHTTP200AndNilErrorAndValidData() {
     let response = httpResponse(with: 200)
-    let (result, error) = RPCResponseHandlerTest.responseHandler.handleResponse(
+    let result = RPCResponseHandlerTest.responseHandler.handleResponse(
       response: response,
       data: testParsedStringData,
       error: nil,
       responseAdapterClass: StringResponseAdapter.self
     )
 
-    XCTAssertNil(error)
-    XCTAssertNotNil(result)
-    XCTAssertEqual(result, RPCResponseHandlerTest.testParsedString)
+    switch result {
+    case .failure:
+      XCTFail()
+    case .success(let data):
+      XCTAssertEqual(data, RPCResponseHandlerTest.testParsedString)
+    }
   }
 
   public func testHandleResponseWithHTTP200AndNilErrorAndNoData() {
     let response = httpResponse(with: 200)
-    let (result, error) = RPCResponseHandlerTest.responseHandler.handleResponse(
+    let result = RPCResponseHandlerTest.responseHandler.handleResponse(
       response: response,
       data: nil,
       error: nil,
       responseAdapterClass: StringResponseAdapter.self
     )
 
-    XCTAssertNotNil(error)
-    XCTAssertNil(result)
-
-    guard let tezosKitError = error as? TezosKitError else {
+    switch result {
+    case .failure(let tezosKitError):
+      XCTAssertEqual(tezosKitError.kind, .unexpectedResponse)
+      XCTAssertEqual(tezosKitError.underlyingError, nil)
+    case .success:
       XCTFail()
-      return
     }
-
-    XCTAssertEqual(tezosKitError.kind, .unexpectedResponse)
-    XCTAssertEqual(tezosKitError.underlyingError, nil)
   }
 
   public func testHandleResponseWithHTTP200AndNilErrorAndBadData() {
     let response = httpResponse(with: 200)
-    let (result, error) = RPCResponseHandlerTest.responseHandler.handleResponse(
+    let result = RPCResponseHandlerTest.responseHandler.handleResponse(
       response: response,
       data: testParsedStringData,
       error: nil,
       responseAdapterClass: PeriodKindResponseAdapter.self
     )
 
-    XCTAssertNotNil(error)
-    XCTAssertNil(result)
-
-    guard let tezosKitError = error as? TezosKitError else {
+    switch result {
+    case .failure(let tezosKitError):
+      XCTAssertEqual(tezosKitError.kind, .unexpectedResponse)
+      XCTAssertEqual(tezosKitError.underlyingError, nil)
+    case .success:
       XCTFail()
-      return
     }
-
-    XCTAssertEqual(tezosKitError.kind, .unexpectedResponse)
-    XCTAssertEqual(tezosKitError.underlyingError, nil)
   }
 
 // MARK: - Helpers

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		77CE387C21FC7ED8006ADABA /* TezosNodeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE384521FC7ED8006ADABA /* TezosNodeClient.swift */; };
 		77CE387D21FC7ED8006ADABA /* TezosKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE384621FC7ED8006ADABA /* TezosKitError.swift */; };
 		77CE388121FC7EED006ADABA /* TezosKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 77CE387F21FC7EED006ADABA /* TezosKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		77DEB6E522373B0E00E4733D /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DEB6E422373B0E00E4733D /* Result.swift */; };
 		77F4D2542218866E00D34B01 /* TezosCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D2532218866E00D34B01 /* TezosCrypto.framework */; };
 		77F4D25622189A5000D34B01 /* RPCResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F4D25522189A5000D34B01 /* RPCResponseHandler.swift */; };
 		77F4D264221CB53900D34B01 /* RPCResponseHandlerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F4D263221CB53900D34B01 /* RPCResponseHandlerTest.swift */; };
@@ -289,6 +290,7 @@
 		77CE384621FC7ED8006ADABA /* TezosKitError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TezosKitError.swift; sourceTree = "<group>"; };
 		77CE387F21FC7EED006ADABA /* TezosKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TezosKit.h; sourceTree = "<group>"; };
 		77CE388021FC7EED006ADABA /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		77DEB6E422373B0E00E4733D /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		77F4D2532218866E00D34B01 /* TezosCrypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = TezosCrypto.framework; path = Carthage/Build/iOS/TezosCrypto.framework; sourceTree = "<group>"; };
 		77F4D25522189A5000D34B01 /* RPCResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCResponseHandler.swift; sourceTree = "<group>"; };
 		77F4D263221CB53900D34B01 /* RPCResponseHandlerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCResponseHandlerTest.swift; sourceTree = "<group>"; };
@@ -433,6 +435,7 @@
 			children = (
 				77CE388021FC7EED006ADABA /* Info.plist */,
 				77CE387F21FC7EED006ADABA /* TezosKit.h */,
+				77DEB6E322373AFD00E4733D /* Core */,
 				77CE384421FC7ED8006ADABA /* Client */,
 				77CE380621FC7ED7006ADABA /* Operation */,
 				77CE381B21FC7ED7006ADABA /* Utils */,
@@ -536,6 +539,14 @@
 				77CE384621FC7ED8006ADABA /* TezosKitError.swift */,
 			);
 			path = Client;
+			sourceTree = "<group>";
+		};
+		77DEB6E322373AFD00E4733D /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				77DEB6E422373B0E00E4733D /* Result.swift */,
+			);
+			path = Core;
 			sourceTree = "<group>";
 		};
 		77F4D26D22220C5200D34B01 /* Extensions */ = {
@@ -834,6 +845,7 @@
 				77CE387A21FC7ED8006ADABA /* PreapplyOperationRPC.swift in Sources */,
 				77CE387121FC7ED8006ADABA /* RPC.swift in Sources */,
 				77CE386321FC7ED8006ADABA /* GetAddressCounterRPC.swift in Sources */,
+				77DEB6E522373B0E00E4733D /* Result.swift in Sources */,
 				77CE386721FC7ED8006ADABA /* TezResponseAdapter.swift in Sources */,
 				77CE385C21FC7ED8006ADABA /* OperationFees.swift in Sources */,
 				77B1EAF1222745F600EA4FCE /* RunOperationRPC.swift in Sources */,

--- a/TezosKit/Client/AbstractClient.swift
+++ b/TezosKit/Client/AbstractClient.swift
@@ -40,12 +40,12 @@ public class AbstractClient {
   /**
    * Send an RPC as a GET or POST request.
    */
-  public func send<T>(_ rpc: RPC<T>, completion: @escaping (T?, Error?) -> Void) {
+  public func send<T>(_ rpc: RPC<T>, completion: @escaping (Result<T, TezosKitError>) -> Void) {
     guard let remoteNodeEndpoint = URL(string: rpc.endpoint, relativeTo: remoteNodeURL) else {
       let errorMessage = "Invalid URL: \(remoteNodeURL)\(rpc.endpoint)"
       let error = TezosKitError(kind: .invalidURL, underlyingError: errorMessage)
       callbackQueue.async {
-        completion(nil, error)
+        completion(.failure(error))
       }
       return
     }
@@ -66,14 +66,14 @@ public class AbstractClient {
         return
       }
 
-      let (result, error) = self.responseHandler.handleResponse(
+      let result = self.responseHandler.handleResponse(
         response: response,
         data: data,
         error: error,
         responseAdapterClass: rpc.responseAdapterClass
       )
       self.callbackQueue.async {
-        completion(result, error)
+        completion(result)
       }
     }
     request.resume()

--- a/TezosKit/Client/TezosNodeClient.swift
+++ b/TezosKit/Client/TezosNodeClient.swift
@@ -90,47 +90,50 @@ public class TezosNodeClient: AbstractClient {
   }
 
   /// Retrieve data about the chain head.
-  public func getHead(completion: @escaping ([String: Any]?, Error?) -> Void) {
+  public func getHead(completion: @escaping (Result<[String: Any], TezosKitError>) -> Void) {
     let rpc = GetChainHeadRPC()
     send(rpc, completion: completion)
   }
 
   /// Retrieve the balance of a given wallet.
-  public func getBalance(wallet: Wallet, completion: @escaping (Tez?, Error?) -> Void) {
+  public func getBalance(wallet: Wallet, completion: @escaping (Result<Tez, TezosKitError>) -> Void) {
     getBalance(address: wallet.address, completion: completion)
   }
 
   /// Retrieve the balance of a given address.
-  public func getBalance(address: String, completion: @escaping (Tez?, Error?) -> Void) {
+  public func getBalance(address: String, completion: @escaping (Result<Tez, TezosKitError>) -> Void) {
     let rpc = GetAddressBalanceRPC(address: address)
     send(rpc, completion: completion)
   }
 
   /// Retrieve the delegate of a given wallet.
-  public func getDelegate(wallet: Wallet, completion: @escaping (String?, Error?) -> Void) {
+  public func getDelegate(wallet: Wallet, completion: @escaping (Result<String, TezosKitError>) -> Void) {
     getDelegate(address: wallet.address, completion: completion)
   }
 
   /// Retrieve the delegate of a given address.
-  public func getDelegate(address: String, completion: @escaping (String?, Error?) -> Void) {
+  public func getDelegate(address: String, completion: @escaping (Result<String, TezosKitError>) -> Void) {
     let rpc = GetDelegateRPC(address: address)
     send(rpc, completion: completion)
   }
 
   /// Retrieve the hash of the block at the head of the chain.
-  public func getHeadHash(completion: @escaping (String?, Error?) -> Void) {
+  public func getHeadHash(completion: @escaping (Result<String, TezosKitError>) -> Void) {
     let rpc = GetChainHeadHashRPC()
     send(rpc, completion: completion)
   }
 
   /// Retrieve the address counter for the given address.
-  public func getAddressCounter(address: String, completion: @escaping (Int?, Error?) -> Void) {
+  public func getAddressCounter(address: String, completion: @escaping (Result<Int, TezosKitError>) -> Void) {
     let rpc = GetAddressCounterRPC(address: address)
     send(rpc, completion: completion)
   }
 
   /// Retrieve the address manager key for the given address.
-  public func getAddressManagerKey(address: String, completion: @escaping ([String: Any]?, Error?) -> Void) {
+  public func getAddressManagerKey(
+    address: String,
+    completion: @escaping (Result<[String: Any], TezosKitError>) -> Void
+  ) {
     let rpc = GetAddressManagerKeyRPC(address: address)
     send(rpc, completion: completion)
   }
@@ -151,7 +154,7 @@ public class TezosNodeClient: AbstractClient {
     keys: Keys,
     parameters: [String: Any]? = nil,
     operationFees: OperationFees? = nil,
-    completion: @escaping (String?, Error?) -> Void
+    completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     let transactionOperation = TransactionOperation(
       amount: amount,
@@ -185,7 +188,7 @@ public class TezosNodeClient: AbstractClient {
     to delegate: String,
     keys: Keys,
     operationFees: OperationFees? = nil,
-    completion: @escaping (String?, Error?) -> Void
+    completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     let delegationOperation = DelegationOperation(source: source, to: delegate, operationFees: operationFees)
     forgeSignPreapplyAndInject(
@@ -209,7 +212,7 @@ public class TezosNodeClient: AbstractClient {
     from source: String,
     keys: Keys,
     operationFees: OperationFees? = nil,
-    completion: @escaping (String?, Error?) -> Void
+    completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     let undelegateOperatoin = UndelegateOperation(source: source, operationFees: operationFees)
     forgeSignPreapplyAndInject(
@@ -230,7 +233,7 @@ public class TezosNodeClient: AbstractClient {
     delegate: String,
     keys: Keys,
     operationFees: OperationFees? = nil,
-    completion: @escaping (String?, Error?) -> Void
+    completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     let registerDelegateOperation = RegisterDelegateOperation(delegate: delegate, operationFees: operationFees)
     forgeSignPreapplyAndInject(
@@ -256,7 +259,7 @@ public class TezosNodeClient: AbstractClient {
     keys: Keys,
     contractCode: ContractCode? = nil,
     operationFees: OperationFees? = nil,
-    completion: @escaping (String?, Error?) -> Void
+    completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     let originateAccountOperation =
       OriginateAccountOperation(address: managerAddress, contractCode: contractCode, operationFees: operationFees)
@@ -273,49 +276,49 @@ public class TezosNodeClient: AbstractClient {
    *
    * - Parameter address: The address of the contract to load.
    */
-  public func getAddressCode(address: String, completion: @escaping (ContractCode?, Error?) -> Void) {
+  public func getAddressCode(address: String, completion: @escaping (Result<ContractCode, TezosKitError>) -> Void) {
     let rpc = GetAddressCodeRPC(address: address)
     send(rpc, completion: completion)
   }
 
   /// Retrieve ballots cast so far during a voting period.
-  public func getBallotsList(completion: @escaping ([[String: Any]]?, Error?) -> Void) {
+  public func getBallotsList(completion: @escaping (Result<[[String: Any]], TezosKitError>) -> Void) {
     let rpc = GetBallotsListRPC()
     send(rpc, completion: completion)
   }
 
   /// Retrieve the expected quorum.
-  public func getExpectedQuorum(completion: @escaping (Int?, Error?) -> Void) {
+  public func getExpectedQuorum(completion: @escaping (Result<Int, TezosKitError>) -> Void) {
     let rpc = GetExpectedQuorumRPC()
     send(rpc, completion: completion)
   }
 
   /// Retrieve the current period kind for voting.
-  public func getCurrentPeriodKind(completion: @escaping (PeriodKind?, Error?) -> Void) {
+  public func getCurrentPeriodKind(completion: @escaping (Result<PeriodKind, TezosKitError>) -> Void) {
     let rpc = GetCurrentPeriodKindRPC()
     send(rpc, completion: completion)
   }
 
   /// Retrieve the sum of ballots cast so far during a voting period.
-  public func getBallots(completion: @escaping ([String: Any]?, Error?) -> Void) {
+  public func getBallots(completion: @escaping (Result<[String: Any], TezosKitError>) -> Void) {
     let rpc = GetBallotsRPC()
     send(rpc, completion: completion)
   }
 
   /// Retrieve a list of proposals with number of supporters.
-  public func getProposalsList(completion: @escaping ([[String: Any]]?, Error?) -> Void) {
+  public func getProposalsList(completion: @escaping (Result<[[String: Any]], TezosKitError>) -> Void) {
     let rpc = GetProposalsListRPC()
     send(rpc, completion: completion)
   }
 
   /// Retrieve the current proposal under evaluation.
-  public func getProposalUnderEvaluation(completion: @escaping (String?, Error?) -> Void) {
+  public func getProposalUnderEvaluation(completion: @escaping (Result<String, TezosKitError>) -> Void) {
     let rpc = GetProposalUnderEvaluationRPC()
     send(rpc, completion: completion)
   }
 
   /// Retrieve a list of delegates with their voting weight, in number of rolls.
-  public func getVotingDelegateRights(completion: @escaping ([[String: Any]]?, Error?) -> Void) {
+  public func getVotingDelegateRights(completion: @escaping (Result<[[String: Any]], TezosKitError>) -> Void) {
     let rpc = GetVotingDelegateRightsRPC()
     send(rpc, completion: completion)
   }
@@ -328,29 +331,41 @@ public class TezosNodeClient: AbstractClient {
   public func runOperation(
     _ operation: Operation,
     from wallet: Wallet,
-    completion: @escaping ([String: Any]?, Error?) -> Void
+    completion: @escaping (Result<[String: Any], TezosKitError>) -> Void
   ) {
-    getMetadataForOperation(address: wallet.address) { [weak self] operationMetadata in
-      guard let self = self,
-            let metadata = operationMetadata else {
-        completion(nil, nil)
+    getMetadataForOperation(address: wallet.address) { [weak self] result in
+      guard let self = self else {
         return
       }
-      let operationPayload = self.createOperationPayload(operations: [operation], operationMetadata: metadata)
-      self.forgeOperation(operationPayload: operationPayload, operationMetadata: metadata) { [weak self] bytes, error in
-        guard let self = self,
-              let bytes = bytes,
-              let (_, signedOperationPayload) = self.sign(
-                operationPayload: operationPayload,
-                forgedPayload: bytes,
-                keys: wallet.keys
-              ) else {
-            let error = TezosKitError(kind: .unknown, underlyingError: nil)
-            completion(nil, error)
+
+      switch result {
+      case .failure(let error):
+        completion(.failure(error))
+        return
+      case .success(let metadata):
+        let operationPayload = self.createOperationPayload(operations: [operation], operationMetadata: metadata)
+        self.forgeOperation(operationPayload: operationPayload, operationMetadata: metadata) { [weak self] result in
+          guard let self = self else {
             return
+          }
+
+          switch result {
+          case .failure(let error):
+            completion(.failure(error))
+          case .success(let bytes):
+            guard let (_, signedOperationPayload) = self.sign(
+              operationPayload: operationPayload,
+              forgedPayload: bytes,
+              keys: wallet.keys
+            ) else {
+              let error = TezosKitError(kind: .signingError, underlyingError: nil)
+              completion(.failure(error))
+              return
+            }
+            let rpc = RunOperationRPC(signedOperationPayload: signedOperationPayload)
+            self.send(rpc, completion: completion)
+          }
         }
-        let rpc = RunOperationRPC(signedOperationPayload: signedOperationPayload)
-        self.send(rpc, completion: completion)
       }
     }
   }
@@ -365,7 +380,7 @@ public class TezosNodeClient: AbstractClient {
   private func forgeOperation(
     operationPayload: OperationPayload,
     operationMetadata: OperationMetadata,
-    completion: @escaping (String?, Error?) -> Void
+    completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     let rpc = ForgeOperationRPC(operationPayload: operationPayload, operationMetadata: operationMetadata)
     self.send(rpc, completion: completion)
@@ -403,7 +418,7 @@ public class TezosNodeClient: AbstractClient {
     _ operation: Operation,
     source: String,
     keys: Keys,
-    completion: @escaping (String?, Error?) -> Void
+    completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     forgeSignPreapplyAndInject(
       [operation],
@@ -427,44 +442,50 @@ public class TezosNodeClient: AbstractClient {
     _ operations: [Operation],
     source: String,
     keys: Keys,
-    completion: @escaping (String?, Error?) -> Void
+    completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
-    getMetadataForOperation(address: source) { [weak self] operationMetadata in
-      guard let self = self,
-            let operationMetadata = operationMetadata else {
-        let error = TezosKitError(kind: .unknown, underlyingError: nil)
-        completion(nil, error)
+    getMetadataForOperation(address: source) { [weak self] result in
+      guard let self = self else {
         return
       }
 
-      // Determine if the address performing the operations has been revealed. If it has not been,
-      // check if any of the operations to perform requires the address to be revealed. If so,
-      // prepend a reveal operation to the operations to perform.
-      var mutableOperations = operations
-      if operationMetadata.key == nil && operations.first(where: { $0.requiresReveal }) != nil {
-        let revealOperation = RevealOperation(from: source, publicKey: keys.publicKey)
-        mutableOperations.insert(revealOperation, at: 0)
-      }
-      let operationPayload =
-        self.createOperationPayload(operations: mutableOperations, operationMetadata: operationMetadata)
-
-      self.forgeOperation(
-        operationPayload: operationPayload,
-        operationMetadata: operationMetadata
-      ) { [weak self] result, error in
-        guard let self = self,
-              let result = result else {
-          completion(nil, error)
-          return
+      switch result {
+      case .failure(let error):
+        completion(.failure(error))
+      case .success(let operationMetadata):
+        // Determine if the address performing the operations has been revealed. If it has not been,
+        // check if any of the operations to perform requires the address to be revealed. If so,
+        // prepend a reveal operation to the operations to perform.
+        var mutableOperations = operations
+        if operationMetadata.key == nil && operations.first(where: { $0.requiresReveal }) != nil {
+          let revealOperation = RevealOperation(from: source, publicKey: keys.publicKey)
+          mutableOperations.insert(revealOperation, at: 0)
         }
-        self.signPreapplyAndInjectOperation(
+        let operationPayload =
+          self.createOperationPayload(operations: mutableOperations, operationMetadata: operationMetadata)
+
+        self.forgeOperation(
           operationPayload: operationPayload,
-          operationMetadata: operationMetadata,
-          forgeResult: result,
-          source: source,
-          keys: keys,
-          completion: completion
-        )
+          operationMetadata: operationMetadata
+        ) { [weak self] result in
+          guard let self = self else {
+            return
+          }
+
+          switch result {
+          case .failure(let error):
+            completion(.failure(error))
+          case .success(let forgedBytes):
+            self.signPreapplyAndInjectOperation(
+              operationPayload: operationPayload,
+              operationMetadata: operationMetadata,
+              forgeResult: forgedBytes,
+              source: source,
+              keys: keys,
+              completion: completion
+            )
+          }
+        }
       }
     }
   }
@@ -509,7 +530,7 @@ public class TezosNodeClient: AbstractClient {
     forgeResult: String,
     source _: String,
     keys: Keys,
-    completion: @escaping (String?, Error?) -> Void
+    completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     guard let (signedBytes, signedOperationPayload) = sign(
       operationPayload: operationPayload,
@@ -517,7 +538,7 @@ public class TezosNodeClient: AbstractClient {
       keys: keys
     ) else {
       let error = TezosKitError(kind: .signingError, underlyingError: "Error signing operation.")
-      completion(nil, error)
+      completion(.failure(error))
       return
     }
 
@@ -544,19 +565,23 @@ public class TezosNodeClient: AbstractClient {
     signedProtocolOperationPayload: SignedProtocolOperationPayload,
     signedBytesForInjection: String,
     operationMetadata: OperationMetadata,
-    completion: @escaping (String?, Error?) -> Void
+    completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
       let preapplyOperationRPC = PreapplyOperationRPC(
         signedProtocolOperationPayload: signedProtocolOperationPayload,
         operationMetadata: operationMetadata
     )
-    send(preapplyOperationRPC) { [weak self] result, error in
-      guard let self = self,
-        result != nil else {
-          completion(nil, error)
-          return
+    send(preapplyOperationRPC) { [weak self] result in
+      guard let self = self else {
+        return
       }
-      self.sendInjectionRPC(payload: signedBytesForInjection, completion: completion)
+
+      switch result {
+      case .failure(let error):
+        completion(.failure(error))
+      case .success:
+        self.sendInjectionRPC(payload: signedBytesForInjection, completion: completion)
+      }
     }
   }
 
@@ -564,10 +589,15 @@ public class TezosNodeClient: AbstractClient {
   /// - Parameters:
   ///   - payload: A JSON compatible string representing the signed operation bytes.
   ///   - completion: A completion block that will be called with the results of the operation.
-  private func sendInjectionRPC(payload: String, completion: @escaping (String?, Error?) -> Void) {
+  private func sendInjectionRPC(payload: String, completion: @escaping (Result<String, TezosKitError>) -> Void) {
     let injectRPC = InjectionRPC(payload: payload)
-    send(injectRPC) { txHash, txError in
-      completion(txHash, txError)
+    send(injectRPC) { result in
+      switch result {
+      case .failure(let txError):
+        completion(.failure(txError))
+      case .success(let txHash):
+        completion(.success(txHash))
+      }
     }
   }
 
@@ -577,7 +607,10 @@ public class TezosNodeClient: AbstractClient {
    * This method parallelizes fetches to get chain and address data and returns all required data
    * together as an OperationData object.
    */
-  private func getMetadataForOperation(address: String, completion: @escaping (OperationMetadata?) -> Void) {
+  private func getMetadataForOperation(
+    address: String,
+    completion: @escaping (Result<OperationMetadata, TezosKitError>) -> Void
+  ) {
     DispatchQueue.global(qos: .userInitiated).async {
       let fetchersGroup = DispatchGroup()
 
@@ -597,31 +630,42 @@ public class TezosNodeClient: AbstractClient {
 
       // Send RPCs and wait for results
       fetchersGroup.enter()
-      self.send(chainHeadRequestRPC) { json, _ in
-        if let json = json,
-           let fetchedChainID = json["chain_id"] as? String,
-          let fetchedHeadHash = json["hash"] as? String,
-          let fetchedProtocolHash = json["protocol"] as? String {
-          chainID = fetchedChainID
-          headHash = fetchedHeadHash
-          protocolHash = fetchedProtocolHash
+      self.send(chainHeadRequestRPC) { result in
+        switch result {
+        case .failure:
+          break
+        case .success(let json):
+          if let fetchedChainID = json["chain_id"] as? String,
+             let fetchedHeadHash = json["hash"] as? String,
+             let fetchedProtocolHash = json["protocol"] as? String {
+            chainID = fetchedChainID
+            headHash = fetchedHeadHash
+            protocolHash = fetchedProtocolHash
+          }
         }
         fetchersGroup.leave()
       }
 
       fetchersGroup.enter()
-      self.send(getAddressCounterRPC) { fetchedOperationCounter, _ in
-        if let fetchedOperationCounter = fetchedOperationCounter {
+      self.send(getAddressCounterRPC) { result in
+        switch result {
+        case .failure:
+          break
+        case .success(let fetchedOperationCounter):
           operationCounter = fetchedOperationCounter
         }
         fetchersGroup.leave()
       }
 
       fetchersGroup.enter()
-      self.send(getAddressManagerKeyRPC) { fetchedManagerAndKey, _ in
-        if let fetchedManagerAndKey = fetchedManagerAndKey,
-          let fetchedKey = fetchedManagerAndKey["key"] as? String {
-          addressKey = fetchedKey
+      self.send(getAddressManagerKeyRPC) { result in
+        switch result {
+        case .failure:
+          break
+        case .success(let fetchedManagerAndKey):
+          if let fetchedKey = fetchedManagerAndKey["key"] as? String {
+            addressKey = fetchedKey
+          }
         }
         fetchersGroup.leave()
       }
@@ -640,10 +684,10 @@ public class TezosNodeClient: AbstractClient {
           addressCounter: operationCounter,
           key: addressKey
         )
-        completion(metadata)
+        completion(.success(metadata))
         return
       }
-      completion(nil)
+      completion(.failure(TezosKitError(kind: .unknown, underlyingError: "Couldn't fetch metadata")))
     }
   }
 }

--- a/TezosKit/Core/Result.swift
+++ b/TezosKit/Core/Result.swift
@@ -1,0 +1,158 @@
+//swiftlint:disable file_header
+
+/// Swift4 compatible code for Result from the Swift 5 library.
+/// This code will be migrated to the official ABI when Swift 5 is GA.
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+/// A value that represents either a success or a failure, including an
+/// associated value in each case.
+public enum Result<Success, Failure: Error> {
+    /// A success, storing a `Success` value.
+    case success(Success)
+
+    /// A failure, storing a `Failure` value.
+    case failure(Failure)
+
+    /// Returns a new result, mapping any success value using the given
+    /// transformation.
+    ///
+    /// Use this method when you need to transform the value of a `Result`
+    /// instance when it represents a success. The following example transforms
+    /// the integer success value of a result into a string:
+    ///
+    ///     func getNextInteger() -> Result<Int, Error> { /* ... */ }
+    ///
+    ///     let integerResult = getNextInteger()
+    ///     // integerResult == .success(5)
+    ///     let stringResult = integerResult.map({ String($0) })
+    ///     // stringResult == .success("5")
+    ///
+    /// - Parameter transform: A closure that takes the success value of this
+    ///   instance.
+    /// - Returns: A `Result` instance with the result of evaluating `transform`
+    ///   as the new success value if this instance represents a success.
+    public func map<NewSuccess>(
+        _ transform: (Success) -> NewSuccess
+        ) -> Result<NewSuccess, Failure> {
+        switch self {
+        case let .success(success):
+            return .success(transform(success))
+        case let .failure(failure):
+            return .failure(failure)
+        }
+    }
+
+    /// Returns a new result, mapping any failure value using the given
+    /// transformation.
+    ///
+    /// Use this method when you need to transform the value of a `Result`
+    /// instance when it represents a failure. The following example transforms
+    /// the error value of a result by wrapping it in a custom `Error` type:
+    ///
+    ///     struct DatedError: Error {
+    ///         var error: Error
+    ///         var date: Date
+    ///
+    ///         init(_ error: Error) {
+    ///             self.error = error
+    ///             self.date = Date()
+    ///         }
+    ///     }
+    ///
+    ///     let result: Result<Int, Error> = // ...
+    ///     // result == .failure(<error value>)
+    ///     let resultWithDatedError = result.mapError({ e in DatedError(e) })
+    ///     // result == .failure(DatedError(error: <error value>, date: <date>))
+    ///
+    /// - Parameter transform: A closure that takes the failure value of the
+    ///   instance.
+    /// - Returns: A `Result` instance with the result of evaluating `transform`
+    ///   as the new failure value if this instance represents a failure.
+    public func mapError<NewFailure>(
+        _ transform: (Failure) -> NewFailure
+        ) -> Result<Success, NewFailure> {
+        switch self {
+        case let .success(success):
+            return .success(success)
+        case let .failure(failure):
+            return .failure(transform(failure))
+        }
+    }
+
+    /// Returns a new result, mapping any success value using the given
+    /// transformation and unwrapping the produced result.
+    ///
+    /// - Parameter transform: A closure that takes the success value of the
+    ///   instance.
+    /// - Returns: A `Result` instance with the result of evaluating `transform`
+    ///   as the new failure value if this instance represents a failure.
+    public func flatMap<NewSuccess>(
+        _ transform: (Success) -> Result<NewSuccess, Failure>
+        ) -> Result<NewSuccess, Failure> {
+        switch self {
+        case let .success(success):
+            return transform(success)
+        case let .failure(failure):
+            return .failure(failure)
+        }
+    }
+
+    /// Returns a new result, mapping any failure value using the given
+    /// transformation and unwrapping the produced result.
+    ///
+    /// - Parameter transform: A closure that takes the failure value of the
+    ///   instance.
+    /// - Returns: A `Result` instance, either from the closure or the previous
+    ///   `.success`.
+    public func flatMapError<NewFailure>(
+        _ transform: (Failure) -> Result<Success, NewFailure>
+        ) -> Result<Success, NewFailure> {
+        switch self {
+        case let .success(success):
+            return .success(success)
+        case let .failure(failure):
+            return transform(failure)
+        }
+    }
+
+    /// Returns the success value as a throwing expression.
+    ///
+    /// Use this method to retrieve the value of this result if it represents a
+    /// success, or to catch the value if it represents a failure.
+    ///
+    ///     let integerResult: Result<Int, Error> = .success(5)
+    ///     do {
+    ///         let value = try integerResult.get()
+    ///         print("The value is \(value).")
+    ///     } catch error {
+    ///         print("Error retrieving the value: \(error)")
+    ///     }
+    ///     // Prints "The value is 5."
+    ///
+    /// - Returns: The success value, if the instance represents a success.
+    /// - Throws: The failure value, if the instance represents a failure.
+    public func get() throws -> Success {
+        switch self {
+        case let .success(success):
+            return success
+        case let .failure(failure):
+            throw failure
+        }
+    }
+}
+
+extension Result: Equatable where Success: Equatable, Failure: Equatable { }
+
+extension Result: Hashable where Success: Hashable, Failure: Hashable { }
+
+//swift:enable file_header


### PR DESCRIPTION
Replace multiple parameter closure blocks with Result objects.

`Result`'s implementation is a paired down implementation from Swift5 and should be able to be swapped in place when Swift 5 is GA.