### PR TITLE
Configurable headers on RPCs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 - gem install cocoapods
 - brew update
 - brew outdated carthage || brew upgrade carthage
+- brew install libsodium
 - carthage bootstrap --platform iOS --cache-builds
 before_deploy:
 - carthage build --no-skip-current --platform iOS --cache-builds

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		7794E972224B0A95000D9F1E /* ConseilNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E971224B0A95000D9F1E /* ConseilNetwork.swift */; };
 		7794E974224B0ACD000D9F1E /* ConseilClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E973224B0ACD000D9F1E /* ConseilClient.swift */; };
 		7794E976224B0AE6000D9F1E /* ConseilTransactionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E975224B0AE6000D9F1E /* ConseilTransactionRequest.swift */; };
+		7794E978224C1A43000D9F1E /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E977224C1A43000D9F1E /* Header.swift */; };
 		77B1EADE222496B500EA4FCE /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */; };
 		77B1EAEA222730D600EA4FCE /* IntegrationTests+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EAE9222730D600EA4FCE /* IntegrationTests+Promises.swift */; };
 		77B1EAED2227342200EA4FCE /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
@@ -189,6 +190,7 @@
 		7794E971224B0A95000D9F1E /* ConseilNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConseilNetwork.swift; path = ../../../../../Documents/ConseilNetwork.swift; sourceTree = "<group>"; };
 		7794E973224B0ACD000D9F1E /* ConseilClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConseilClient.swift; path = ../../../../../Documents/ConseilClient.swift; sourceTree = "<group>"; };
 		7794E975224B0AE6000D9F1E /* ConseilTransactionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConseilTransactionRequest.swift; path = ../../../../../Documents/ConseilTransactionRequest.swift; sourceTree = "<group>"; };
+		7794E977224C1A43000D9F1E /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeClient+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAE9222730D600EA4FCE /* IntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntegrationTests+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAF0222745F600EA4FCE /* RunOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunOperationRPC.swift; sourceTree = "<group>"; };
@@ -504,6 +506,7 @@
 			children = (
 				77B1EAFA2228B7F300EA4FCE /* Payload */,
 				77CE382821FC7ED7006ADABA /* GetAddressBalanceRPC.swift */,
+				7794E977224C1A43000D9F1E /* Header.swift */,
 				77B1EAF0222745F600EA4FCE /* RunOperationRPC.swift */,
 				77CE382921FC7ED7006ADABA /* GetChainHeadHashRPC.swift */,
 				77CE382A21FC7ED7006ADABA /* GetAddressCounterRPC.swift */,
@@ -911,6 +914,7 @@
 				77B1EB06222A102500EA4FCE /* OperationWithCounter.swift in Sources */,
 				77CE385D21FC7ED8006ADABA /* PeriodKind.swift in Sources */,
 				77CE387321FC7ED8006ADABA /* GetAddressManagerKeyRPC.swift in Sources */,
+				7794E978224C1A43000D9F1E /* Header.swift in Sources */,
 				77B1EAF322275A4A00EA4FCE /* GasLimitPolicy.swift in Sources */,
 				77CE384921FC7ED8006ADABA /* AbstractOperation.swift in Sources */,
 				77CE387221FC7ED8006ADABA /* InjectOperationRPC.swift in Sources */,

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -14,11 +14,6 @@
 		7774780B2222281B0010BA4D /* TezosKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CE359621F7DC76006ADABA /* TezosKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		7774780C222228590010BA4D /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
 		7774780F222228E50010BA4D /* PromiseKit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7774780E222228E50010BA4D /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		7794E970224B0A68000D9F1E /* ConseilPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E96F224B0A68000D9F1E /* ConseilPlatform.swift */; };
-		7794E972224B0A95000D9F1E /* ConseilNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E971224B0A95000D9F1E /* ConseilNetwork.swift */; };
-		7794E974224B0ACD000D9F1E /* ConseilClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E973224B0ACD000D9F1E /* ConseilClient.swift */; };
-		7794E976224B0AE6000D9F1E /* ConseilTransactionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E975224B0AE6000D9F1E /* ConseilTransactionRequest.swift */; };
-		7794E978224C1A43000D9F1E /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E977224C1A43000D9F1E /* Header.swift */; };
 		77B1EADE222496B500EA4FCE /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */; };
 		77B1EAEA222730D600EA4FCE /* IntegrationTests+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EAE9222730D600EA4FCE /* IntegrationTests+Promises.swift */; };
 		77B1EAED2227342200EA4FCE /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
@@ -186,11 +181,6 @@
 		7774780422221DE50010BA4D /* AbstractClientTest+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractClientTest+Promises.swift"; sourceTree = "<group>"; };
 		7774780E222228E50010BA4D /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromiseKit.framework; path = Carthage/Build/iOS/PromiseKit.framework; sourceTree = "<group>"; };
 		7791E60F21FE862600957650 /* TezosKitExample.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = TezosKitExample.playground; path = Examples/TezosKitExample.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		7794E96F224B0A68000D9F1E /* ConseilPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConseilPlatform.swift; path = ../../../../../Documents/ConseilPlatform.swift; sourceTree = "<group>"; };
-		7794E971224B0A95000D9F1E /* ConseilNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConseilNetwork.swift; path = ../../../../../Documents/ConseilNetwork.swift; sourceTree = "<group>"; };
-		7794E973224B0ACD000D9F1E /* ConseilClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConseilClient.swift; path = ../../../../../Documents/ConseilClient.swift; sourceTree = "<group>"; };
-		7794E975224B0AE6000D9F1E /* ConseilTransactionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConseilTransactionRequest.swift; path = ../../../../../Documents/ConseilTransactionRequest.swift; sourceTree = "<group>"; };
-		7794E977224C1A43000D9F1E /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeClient+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAE9222730D600EA4FCE /* IntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntegrationTests+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAF0222745F600EA4FCE /* RunOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunOperationRPC.swift; sourceTree = "<group>"; };
@@ -349,18 +339,6 @@
 			path = IntegrationTests;
 			sourceTree = "<group>";
 		};
-		7794E96E224B0A32000D9F1E /* Conseil */ = {
-			isa = PBXGroup;
-			children = (
-				7794E96F224B0A68000D9F1E /* ConseilPlatform.swift */,
-				7794E975224B0AE6000D9F1E /* ConseilTransactionRequest.swift */,
-				7794E973224B0ACD000D9F1E /* ConseilClient.swift */,
-				7794E971224B0A95000D9F1E /* ConseilNetwork.swift */,
-			);
-			name = Conseil;
-			path = Core/Conseil;
-			sourceTree = "<group>";
-		};
 		77B1EAE62225CE8400EA4FCE /* TezosKit */ = {
 			isa = PBXGroup;
 			children = (
@@ -450,7 +428,6 @@
 			isa = PBXGroup;
 			children = (
 				77CE388021FC7EED006ADABA /* Info.plist */,
-				7794E96E224B0A32000D9F1E /* Conseil */,
 				77CE387F21FC7EED006ADABA /* TezosKit.h */,
 				77DEB6E322373AFD00E4733D /* Core */,
 				77CE384421FC7ED8006ADABA /* Client */,
@@ -506,7 +483,6 @@
 			children = (
 				77B1EAFA2228B7F300EA4FCE /* Payload */,
 				77CE382821FC7ED7006ADABA /* GetAddressBalanceRPC.swift */,
-				7794E977224C1A43000D9F1E /* Header.swift */,
 				77B1EAF0222745F600EA4FCE /* RunOperationRPC.swift */,
 				77CE382921FC7ED7006ADABA /* GetChainHeadHashRPC.swift */,
 				77CE382A21FC7ED7006ADABA /* GetAddressCounterRPC.swift */,
@@ -736,11 +712,9 @@
 					};
 					77CE359521F7DC76006ADABA = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1020;
 					};
 					77CE359E21F7DC76006ADABA = {
 						CreatedOnToolsVersion = 10.1;
-						LastSwiftMigration = 1020;
 					};
 				};
 			};
@@ -865,9 +839,7 @@
 				77DEB6E522373B0E00E4733D /* Result.swift in Sources */,
 				77CE386721FC7ED8006ADABA /* TezResponseAdapter.swift in Sources */,
 				77CE385C21FC7ED8006ADABA /* OperationFees.swift in Sources */,
-				7794E970224B0A68000D9F1E /* ConseilPlatform.swift in Sources */,
 				77B1EAF1222745F600EA4FCE /* RunOperationRPC.swift in Sources */,
-				7794E976224B0AE6000D9F1E /* ConseilTransactionRequest.swift in Sources */,
 				77CE385821FC7ED8006ADABA /* MnemonicUtil.swift in Sources */,
 				77CE384A21FC7ED8006ADABA /* RevealOperation.swift in Sources */,
 				77B1EAF52228839000EA4FCE /* OperationPayload.swift in Sources */,
@@ -896,7 +868,6 @@
 				77F4D26F22220C9600D34B01 /* AbstractClient+Promises.swift in Sources */,
 				77F4D25622189A5000D34B01 /* RPCResponseHandler.swift in Sources */,
 				77CE385721FC7ED8006ADABA /* JSONUtils.swift in Sources */,
-				7794E972224B0A95000D9F1E /* ConseilNetwork.swift in Sources */,
 				77CE387521FC7ED8006ADABA /* GetProposalUnderEvaluationRPC.swift in Sources */,
 				77CE387721FC7ED8006ADABA /* GetVotingDelegateRightsRPC.swift in Sources */,
 				77B1EAF922289B9800EA4FCE /* SignedProtocolOperationPayload.swift in Sources */,
@@ -904,7 +875,6 @@
 				77CE386421FC7ED8006ADABA /* GetBallotsRPC.swift in Sources */,
 				77CE387C21FC7ED8006ADABA /* TezosNodeClient.swift in Sources */,
 				77CE385E21FC7ED8006ADABA /* Wallet.swift in Sources */,
-				7794E974224B0ACD000D9F1E /* ConseilClient.swift in Sources */,
 				77CE384D21FC7ED8006ADABA /* TransactionOperation.swift in Sources */,
 				77CE386621FC7ED8006ADABA /* GetProposalsListRPC.swift in Sources */,
 				77CE387D21FC7ED8006ADABA /* TezosKitError.swift in Sources */,
@@ -914,7 +884,6 @@
 				77B1EB06222A102500EA4FCE /* OperationWithCounter.swift in Sources */,
 				77CE385D21FC7ED8006ADABA /* PeriodKind.swift in Sources */,
 				77CE387321FC7ED8006ADABA /* GetAddressManagerKeyRPC.swift in Sources */,
-				7794E978224C1A43000D9F1E /* Header.swift in Sources */,
 				77B1EAF322275A4A00EA4FCE /* GasLimitPolicy.swift in Sources */,
 				77CE384921FC7ED8006ADABA /* AbstractOperation.swift in Sources */,
 				77CE387221FC7ED8006ADABA /* InjectOperationRPC.swift in Sources */,
@@ -1179,7 +1148,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.TezosKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1209,7 +1178,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.TezosKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1232,7 +1201,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.TezosKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1255,7 +1224,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.TezosKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -14,6 +14,10 @@
 		7774780B2222281B0010BA4D /* TezosKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CE359621F7DC76006ADABA /* TezosKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		7774780C222228590010BA4D /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
 		7774780F222228E50010BA4D /* PromiseKit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7774780E222228E50010BA4D /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7794E970224B0A68000D9F1E /* ConseilPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E96F224B0A68000D9F1E /* ConseilPlatform.swift */; };
+		7794E972224B0A95000D9F1E /* ConseilNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E971224B0A95000D9F1E /* ConseilNetwork.swift */; };
+		7794E974224B0ACD000D9F1E /* ConseilClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E973224B0ACD000D9F1E /* ConseilClient.swift */; };
+		7794E976224B0AE6000D9F1E /* ConseilTransactionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E975224B0AE6000D9F1E /* ConseilTransactionRequest.swift */; };
 		77B1EADE222496B500EA4FCE /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */; };
 		77B1EAEA222730D600EA4FCE /* IntegrationTests+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EAE9222730D600EA4FCE /* IntegrationTests+Promises.swift */; };
 		77B1EAED2227342200EA4FCE /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
@@ -181,6 +185,10 @@
 		7774780422221DE50010BA4D /* AbstractClientTest+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractClientTest+Promises.swift"; sourceTree = "<group>"; };
 		7774780E222228E50010BA4D /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromiseKit.framework; path = Carthage/Build/iOS/PromiseKit.framework; sourceTree = "<group>"; };
 		7791E60F21FE862600957650 /* TezosKitExample.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = TezosKitExample.playground; path = Examples/TezosKitExample.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		7794E96F224B0A68000D9F1E /* ConseilPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConseilPlatform.swift; path = ../../../../../Documents/ConseilPlatform.swift; sourceTree = "<group>"; };
+		7794E971224B0A95000D9F1E /* ConseilNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConseilNetwork.swift; path = ../../../../../Documents/ConseilNetwork.swift; sourceTree = "<group>"; };
+		7794E973224B0ACD000D9F1E /* ConseilClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConseilClient.swift; path = ../../../../../Documents/ConseilClient.swift; sourceTree = "<group>"; };
+		7794E975224B0AE6000D9F1E /* ConseilTransactionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConseilTransactionRequest.swift; path = ../../../../../Documents/ConseilTransactionRequest.swift; sourceTree = "<group>"; };
 		77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeClient+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAE9222730D600EA4FCE /* IntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntegrationTests+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAF0222745F600EA4FCE /* RunOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunOperationRPC.swift; sourceTree = "<group>"; };
@@ -339,6 +347,18 @@
 			path = IntegrationTests;
 			sourceTree = "<group>";
 		};
+		7794E96E224B0A32000D9F1E /* Conseil */ = {
+			isa = PBXGroup;
+			children = (
+				7794E96F224B0A68000D9F1E /* ConseilPlatform.swift */,
+				7794E975224B0AE6000D9F1E /* ConseilTransactionRequest.swift */,
+				7794E973224B0ACD000D9F1E /* ConseilClient.swift */,
+				7794E971224B0A95000D9F1E /* ConseilNetwork.swift */,
+			);
+			name = Conseil;
+			path = Core/Conseil;
+			sourceTree = "<group>";
+		};
 		77B1EAE62225CE8400EA4FCE /* TezosKit */ = {
 			isa = PBXGroup;
 			children = (
@@ -428,6 +448,7 @@
 			isa = PBXGroup;
 			children = (
 				77CE388021FC7EED006ADABA /* Info.plist */,
+				7794E96E224B0A32000D9F1E /* Conseil */,
 				77CE387F21FC7EED006ADABA /* TezosKit.h */,
 				77DEB6E322373AFD00E4733D /* Core */,
 				77CE384421FC7ED8006ADABA /* Client */,
@@ -712,9 +733,11 @@
 					};
 					77CE359521F7DC76006ADABA = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1020;
 					};
 					77CE359E21F7DC76006ADABA = {
 						CreatedOnToolsVersion = 10.1;
+						LastSwiftMigration = 1020;
 					};
 				};
 			};
@@ -813,7 +836,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint --strict\nelse\necho \"warning: SwiftLint not installed, run `brew install swiftlint`\"\nfi\n";
+			shellScript = "#if which swiftlint >/dev/null; then\n#swiftlint --strict\n#else\n#echo \"warning: SwiftLint not installed, run `brew install swiftlint`\"\n#fi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -839,7 +862,9 @@
 				77DEB6E522373B0E00E4733D /* Result.swift in Sources */,
 				77CE386721FC7ED8006ADABA /* TezResponseAdapter.swift in Sources */,
 				77CE385C21FC7ED8006ADABA /* OperationFees.swift in Sources */,
+				7794E970224B0A68000D9F1E /* ConseilPlatform.swift in Sources */,
 				77B1EAF1222745F600EA4FCE /* RunOperationRPC.swift in Sources */,
+				7794E976224B0AE6000D9F1E /* ConseilTransactionRequest.swift in Sources */,
 				77CE385821FC7ED8006ADABA /* MnemonicUtil.swift in Sources */,
 				77CE384A21FC7ED8006ADABA /* RevealOperation.swift in Sources */,
 				77B1EAF52228839000EA4FCE /* OperationPayload.swift in Sources */,
@@ -868,6 +893,7 @@
 				77F4D26F22220C9600D34B01 /* AbstractClient+Promises.swift in Sources */,
 				77F4D25622189A5000D34B01 /* RPCResponseHandler.swift in Sources */,
 				77CE385721FC7ED8006ADABA /* JSONUtils.swift in Sources */,
+				7794E972224B0A95000D9F1E /* ConseilNetwork.swift in Sources */,
 				77CE387521FC7ED8006ADABA /* GetProposalUnderEvaluationRPC.swift in Sources */,
 				77CE387721FC7ED8006ADABA /* GetVotingDelegateRightsRPC.swift in Sources */,
 				77B1EAF922289B9800EA4FCE /* SignedProtocolOperationPayload.swift in Sources */,
@@ -875,6 +901,7 @@
 				77CE386421FC7ED8006ADABA /* GetBallotsRPC.swift in Sources */,
 				77CE387C21FC7ED8006ADABA /* TezosNodeClient.swift in Sources */,
 				77CE385E21FC7ED8006ADABA /* Wallet.swift in Sources */,
+				7794E974224B0ACD000D9F1E /* ConseilClient.swift in Sources */,
 				77CE384D21FC7ED8006ADABA /* TransactionOperation.swift in Sources */,
 				77CE386621FC7ED8006ADABA /* GetProposalsListRPC.swift in Sources */,
 				77CE387D21FC7ED8006ADABA /* TezosKitError.swift in Sources */,
@@ -1148,7 +1175,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.TezosKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1178,7 +1205,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.TezosKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1201,7 +1228,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.TezosKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1224,7 +1251,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.TezosKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7774780B2222281B0010BA4D /* TezosKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77CE359621F7DC76006ADABA /* TezosKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		7774780C222228590010BA4D /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
 		7774780F222228E50010BA4D /* PromiseKit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7774780E222228E50010BA4D /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7794E97B224C2518000D9F1E /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E97A224C2518000D9F1E /* Header.swift */; };
 		77B1EADE222496B500EA4FCE /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */; };
 		77B1EAEA222730D600EA4FCE /* IntegrationTests+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EAE9222730D600EA4FCE /* IntegrationTests+Promises.swift */; };
 		77B1EAED2227342200EA4FCE /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
@@ -181,6 +182,7 @@
 		7774780422221DE50010BA4D /* AbstractClientTest+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractClientTest+Promises.swift"; sourceTree = "<group>"; };
 		7774780E222228E50010BA4D /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromiseKit.framework; path = Carthage/Build/iOS/PromiseKit.framework; sourceTree = "<group>"; };
 		7791E60F21FE862600957650 /* TezosKitExample.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = TezosKitExample.playground; path = Examples/TezosKitExample.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		7794E97A224C2518000D9F1E /* Header.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeClient+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAE9222730D600EA4FCE /* IntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntegrationTests+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAF0222745F600EA4FCE /* RunOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunOperationRPC.swift; sourceTree = "<group>"; };
@@ -485,6 +487,7 @@
 				77CE382821FC7ED7006ADABA /* GetAddressBalanceRPC.swift */,
 				77B1EAF0222745F600EA4FCE /* RunOperationRPC.swift */,
 				77CE382921FC7ED7006ADABA /* GetChainHeadHashRPC.swift */,
+				7794E97A224C2518000D9F1E /* Header.swift */,
 				77CE382A21FC7ED7006ADABA /* GetAddressCounterRPC.swift */,
 				77CE382B21FC7ED7006ADABA /* GetBallotsRPC.swift */,
 				77CE382C21FC7ED7006ADABA /* GetAddressCodeRPC.swift */,
@@ -850,6 +853,7 @@
 				77CE384E21FC7ED8006ADABA /* OperationKind.swift in Sources */,
 				77CE386D21FC7ED8006ADABA /* PeriodKindResponseAdapter.swift in Sources */,
 				77CE386521FC7ED8006ADABA /* GetAddressCodeRPC.swift in Sources */,
+				7794E97B224C2518000D9F1E /* Header.swift in Sources */,
 				77CE385921FC7ED8006ADABA /* Tez.swift in Sources */,
 				77CE385F21FC7ED8006ADABA /* ContractCode.swift in Sources */,
 				77CE386821FC7ED8006ADABA /* ResponseAdapter.swift in Sources */,

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -836,7 +836,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#if which swiftlint >/dev/null; then\n#swiftlint --strict\n#else\n#echo \"warning: SwiftLint not installed, run `brew install swiftlint`\"\n#fi\n";
+			shellScript = "if which swiftlint >/dev/null; then\nswiftlint --strict\nelse\necho \"warning: SwiftLint not installed, run `brew install swiftlint`\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/TezosKit/Client/AbstractClient.swift
+++ b/TezosKit/Client/AbstractClient.swift
@@ -52,9 +52,12 @@ public class AbstractClient {
       let payload = rpc.payload,
       let payloadData = payload.data(using: .utf8) {
       urlRequest.httpMethod = "POST"
-      urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
       urlRequest.cachePolicy = .reloadIgnoringCacheData
       urlRequest.httpBody = payloadData
+    }
+
+    for header in rpc.headers {
+      urlRequest.addValue(header.value, forHTTPHeaderField: header.field)
     }
 
     let request = urlSession.dataTask(with: urlRequest) { [weak self] data, response, error in

--- a/TezosKit/RPC/ForgeOperationRPC.swift
+++ b/TezosKit/RPC/ForgeOperationRPC.swift
@@ -16,7 +16,7 @@ public class ForgeOperationRPC: RPC<String> {
     let payload = JSONUtils.jsonString(for: operationPayload.dictionaryRepresentation)
     super.init(
       endpoint: endpoint,
-      headers: RPC.Headers.contentTypeJSON()
+      headers: [Header.contentTypeApplicationJSON],
       responseAdapterClass: StringResponseAdapter.self,
       payload: payload
     )

--- a/TezosKit/RPC/ForgeOperationRPC.swift
+++ b/TezosKit/RPC/ForgeOperationRPC.swift
@@ -16,6 +16,7 @@ public class ForgeOperationRPC: RPC<String> {
     let payload = JSONUtils.jsonString(for: operationPayload.dictionaryRepresentation)
     super.init(
       endpoint: endpoint,
+      headers: RPC.Headers.contentTypeJSON()
       responseAdapterClass: StringResponseAdapter.self,
       payload: payload
     )

--- a/TezosKit/RPC/GetAddressBalanceRPC.swift
+++ b/TezosKit/RPC/GetAddressBalanceRPC.swift
@@ -2,13 +2,9 @@
 
 import Foundation
 
-/**
- * An RPC that will retrieve the balance of a given address.
- */
+/// An RPC that will retrieve the balance of a given address.
 public class GetAddressBalanceRPC: RPC<Tez> {
-  /**
-   * - Parameter address: The address to retrieve info about.
-   */
+  /// - Parameter address: The address to retrieve info about.
   public init(address: String) {
     let endpoint = "/chains/main/blocks/head/context/contracts/" + address + "/balance"
     super.init(endpoint: endpoint, responseAdapterClass: TezResponseAdapter.self)

--- a/TezosKit/RPC/GetChainHeadHashRPC.swift
+++ b/TezosKit/RPC/GetChainHeadHashRPC.swift
@@ -2,9 +2,7 @@
 
 import Foundation
 
-/**
- * An RPC which will retrieve the hash of the head of the main chain.
- */
+/// An RPC which will retrieve the hash of the head of the main chain.
 public class GetChainHeadHashRPC: RPC<String> {
   public init() {
     let endpoint = "chains/main/blocks/head/hash"

--- a/TezosKit/RPC/Header.swift
+++ b/TezosKit/RPC/Header.swift
@@ -1,0 +1,11 @@
+// Copyright Keefer Taylor, 2019
+
+import Foundation
+
+/// An encapsulation of headers to use in an RPC.
+public struct Header {
+  public static let contentTypeApplicationJSON = Header(field: "Content-Type", value: "application/json")
+
+  public let field: String
+  public let value: String
+}

--- a/TezosKit/RPC/InjectOperationRPC.swift
+++ b/TezosKit/RPC/InjectOperationRPC.swift
@@ -11,7 +11,7 @@ public class InjectionRPC: RPC<String> {
     let endpoint = "/injection/operation"
     super.init(
       endpoint: endpoint,
-      headers: RPC.Headers.contentTypeJSON()
+      headers: [Header.contentTypeApplicationJSON],
       responseAdapterClass: StringResponseAdapter.self,
       payload: payload
     )

--- a/TezosKit/RPC/InjectOperationRPC.swift
+++ b/TezosKit/RPC/InjectOperationRPC.swift
@@ -2,19 +2,16 @@
 
 import Foundation
 
-/**
- * An RPC which will inject an operation on the Tezos blockchain.
- */
+/// An RPC which will inject an operation on the Tezos blockchain.
 public class InjectionRPC: RPC<String> {
-  /**
-   * - Parameter payload: A JSON encoded string that represents the signed payload to inject.
-   */
+  /// - Parameter payload: A JSON encoded string that represents the signed payload to inject.
   public init(
     payload: String
   ) {
     let endpoint = "/injection/operation"
     super.init(
       endpoint: endpoint,
+      headers: RPC.Headers.contentTypeJSON()
       responseAdapterClass: StringResponseAdapter.self,
       payload: payload
     )

--- a/TezosKit/RPC/PreapplyOperationRPC.swift
+++ b/TezosKit/RPC/PreapplyOperationRPC.swift
@@ -16,6 +16,7 @@ public class PreapplyOperationRPC: RPC<[[String: Any]]> {
     let payload = JSONUtils.jsonString(for: signedProtocolOperationPayload.dictionaryRepresentation)
     super.init(
       endpoint: endpoint,
+      headers: RPC.Headers.contentTypeJSON()
       responseAdapterClass: JSONArrayResponseAdapter.self,
       payload: payload
     )

--- a/TezosKit/RPC/PreapplyOperationRPC.swift
+++ b/TezosKit/RPC/PreapplyOperationRPC.swift
@@ -16,7 +16,7 @@ public class PreapplyOperationRPC: RPC<[[String: Any]]> {
     let payload = JSONUtils.jsonString(for: signedProtocolOperationPayload.dictionaryRepresentation)
     super.init(
       endpoint: endpoint,
-      headers: RPC.Headers.contentTypeJSON()
+      headers: [Header.contentTypeApplicationJSON],
       responseAdapterClass: JSONArrayResponseAdapter.self,
       payload: payload
     )

--- a/TezosKit/RPC/RPC.swift
+++ b/TezosKit/RPC/RPC.swift
@@ -2,6 +2,14 @@
 
 import Foundation
 
+/// An encapsulation of headers to use in an RPC.
+public struct Header {
+  public static let contentTypeApplicationJSON = Header(field: "Content-Type", value: "application/json")
+
+  public let field: String
+  public let value: String
+}
+
 ///An abstract RPC class that defines a request and response handler.
 ///
 /// RPCs have a generic type associated with them, which is the expected type of the decoded bytes received from the
@@ -13,15 +21,8 @@ import Foundation
 ///
 /// Concrete subclasses should construct an endpoint and payload and inform this class by calling `super.init`.
 public class RPC<T> {
-  /// Re-useable headers.
-  public enum Headers {
-    public static func contentTypeJSON() -> [String: String ]{
-      return ["Content-Type": "application/json"]
-    }
-  }
-
   public let endpoint: String
-  public let headers: [[String: String]]?
+  public let headers: [Header]
   public let payload: String?
   public let responseAdapterClass: AbstractResponseAdapter<T>.Type
   public var isPOSTRequest: Bool {
@@ -38,13 +39,13 @@ public class RPC<T> {
   ///
   /// - Parameters:
   ///   - endpoint: The endpoint to which the request is being made.
-  ///   - headers: An optional dictionary of headers to use.
+  ///   - headers: A dictionary of headers to use, default is empty headers.
   ///   - responseAdapterClass: The class of the response adapter which will take bytes received from the request and
   ///     transform them into a specific type.
   ///   - payload: A payload that should be sent with a POST request.
   public init(
     endpoint: String,
-    headers: [[String : String]]? = nil,
+    headers: [Header] = [],
     responseAdapterClass: AbstractResponseAdapter<T>.Type,
     payload: String? = nil
   ) {

--- a/TezosKit/RPC/RPC.swift
+++ b/TezosKit/RPC/RPC.swift
@@ -13,8 +13,15 @@ import Foundation
 ///
 /// Concrete subclasses should construct an endpoint and payload and inform this class by calling `super.init`.
 public class RPC<T> {
+  /// Re-useable headers.
+  public enum Headers {
+    public static func contentTypeJSON() -> [String: String ]{
+      return ["Content-Type": "application/json"]
+    }
+  }
+
   public let endpoint: String
-  public let headers: [String: String]?
+  public let headers: [[String: String]]?
   public let payload: String?
   public let responseAdapterClass: AbstractResponseAdapter<T>.Type
   public var isPOSTRequest: Bool {
@@ -37,7 +44,7 @@ public class RPC<T> {
   ///   - payload: A payload that should be sent with a POST request.
   public init(
     endpoint: String,
-    headers: [String : String]? = nil,
+    headers: [[String : String]]? = nil,
     responseAdapterClass: AbstractResponseAdapter<T>.Type,
     payload: String? = nil
   ) {

--- a/TezosKit/RPC/RPC.swift
+++ b/TezosKit/RPC/RPC.swift
@@ -2,14 +2,6 @@
 
 import Foundation
 
-/// An encapsulation of headers to use in an RPC.
-public struct Header {
-  public static let contentTypeApplicationJSON = Header(field: "Content-Type", value: "application/json")
-
-  public let field: String
-  public let value: String
-}
-
 ///An abstract RPC class that defines a request and response handler.
 ///
 /// RPCs have a generic type associated with them, which is the expected type of the decoded bytes received from the

--- a/TezosKit/RPC/RPC.swift
+++ b/TezosKit/RPC/RPC.swift
@@ -2,21 +2,19 @@
 
 import Foundation
 
-/**
- * An abstract RPC class that defines a request and response handler.
- *
- * RPCs have a generic type associated with them, which is the expected type of the decoded bytes
- * recived from the network. The given RepsonseAdapter must meet this type.
- *
- * RPCs represent a network request to the Tezos network. RPCs are implicitly considered GET
- * requests by default. If a payload is defined, then the RPC should be interpreted as a POST. This
- * schema is represented in the derived |isPOSTRequest| variable.
- *
- * Concrete subclasses should construct an endpoint and payload and inform this class by calling
- * |super.init|.
- */
+///An abstract RPC class that defines a request and response handler.
+///
+/// RPCs have a generic type associated with them, which is the expected type of the decoded bytes received from the
+/// network. The given RepsonseAdapter must meet this type.
+///
+/// RPCs represent a network request to the Tezos network. RPCs are implicitly considered GET requests by default. If a
+/// payload is defined, then the RPC should be interpreted as a POST. This schema is represented in the derived
+/// `isPOSTRequest` property.
+///
+/// Concrete subclasses should construct an endpoint and payload and inform this class by calling `super.init`.
 public class RPC<T> {
   public let endpoint: String
+  public let headers: [String: String]?
   public let payload: String?
   public let responseAdapterClass: AbstractResponseAdapter<T>.Type
   public var isPOSTRequest: Bool {
@@ -26,24 +24,25 @@ public class RPC<T> {
     return false
   }
 
-  /**
-   * Initialize a new request.
-   *
-   * By default, requests are considered to be GET requests with an empty body. If payload is set
-   * the request should be interpreted as a POST request with the given payload.
-   *
-   * - Parameter endpoint: The endpoint to which the request is being made.
-   * - Parameter responseAdapterClass: The class of the response adapter which will take bytes received from the
-   *             request and transform them into a specific type.
-   * - Parameter payload: A payload that should be sent with a POST request.
-   * - Parameter completion: A completion block which will be called at the end of the request.
-   */
+  /// Initialize a new request.
+  ///
+  /// By default, requests are considered to be GET requests with an empty body. If payload is set the request should be
+  /// interpreted as a POST request with the given payload.
+  ///
+  /// - Parameters:
+  ///   - endpoint: The endpoint to which the request is being made.
+  ///   - headers: An optional dictionary of headers to use.
+  ///   - responseAdapterClass: The class of the response adapter which will take bytes received from the request and
+  ///     transform them into a specific type.
+  ///   - payload: A payload that should be sent with a POST request.
   public init(
     endpoint: String,
+    headers: [String : String]? = nil,
     responseAdapterClass: AbstractResponseAdapter<T>.Type,
     payload: String? = nil
   ) {
     self.endpoint = endpoint
+    self.headers = headers
     self.responseAdapterClass = responseAdapterClass
     self.payload = payload
   }

--- a/TezosKit/RPC/RunOperationRPC.swift
+++ b/TezosKit/RPC/RunOperationRPC.swift
@@ -10,6 +10,7 @@ public class RunOperationRPC: RPC<[String: Any]> {
     let jsonPayload = JSONUtils.jsonString(for: signedOperationPayload.dictionaryRepresentation)
     super.init(
       endpoint: endpoint,
+      headers: RPC.Headers.contentTypeJSON()
       responseAdapterClass: JSONDictionaryResponseAdapter.self,
       payload: jsonPayload
     )

--- a/TezosKit/RPC/RunOperationRPC.swift
+++ b/TezosKit/RPC/RunOperationRPC.swift
@@ -10,7 +10,7 @@ public class RunOperationRPC: RPC<[String: Any]> {
     let jsonPayload = JSONUtils.jsonString(for: signedOperationPayload.dictionaryRepresentation)
     super.init(
       endpoint: endpoint,
-      headers: RPC.Headers.contentTypeJSON()
+      headers: [Header.contentTypeApplicationJSON],
       responseAdapterClass: JSONDictionaryResponseAdapter.self,
       payload: jsonPayload
     )


### PR DESCRIPTION
Configure RPCs to support custom headers. 

Previously, the only header that needed to be supported was `"Content-Type": "application/json"`. This refactors headers to be configurable per request object rather than hardcoded at the client level.

Prefactor for Conseil integration.

Addresses #2 