### PR TITLE
Initial Conseil Support

### DIFF
--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		77B69EA4224C38C700DB4319 /* ConseilClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EA3224C38C700DB4319 /* ConseilClient.swift */; };
 		77B69EA7224C392300DB4319 /* ConseilPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EA6224C392300DB4319 /* ConseilPlatform.swift */; };
 		77B69EA9224C39AC00DB4319 /* ConseilNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EA8224C39AC00DB4319 /* ConseilNetwork.swift */; };
-		77B69EAB224C3A5300DB4319 /* FetchSentTransactionsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EAA224C3A5300DB4319 /* FetchSentTransactionsRPC.swift */; };
+		77B69EAB224C3A5300DB4319 /* GetSentTransactionsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EAA224C3A5300DB4319 /* GetSentTransactionsRPC.swift */; };
 		77CE36E021F7F49F006ADABA /* IntegerResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36B921F7F49C006ADABA /* IntegerResponseAdapterTest.swift */; };
 		77CE36E121F7F49F006ADABA /* RevealOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BA21F7F49C006ADABA /* RevealOperationTest.swift */; };
 		77CE36E221F7F49F006ADABA /* ForgeOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BB21F7F49C006ADABA /* ForgeOperationRPCTest.swift */; };
@@ -204,7 +204,7 @@
 		77B69EA3224C38C700DB4319 /* ConseilClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilClient.swift; sourceTree = "<group>"; };
 		77B69EA6224C392300DB4319 /* ConseilPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilPlatform.swift; sourceTree = "<group>"; };
 		77B69EA8224C39AC00DB4319 /* ConseilNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilNetwork.swift; sourceTree = "<group>"; };
-		77B69EAA224C3A5300DB4319 /* FetchSentTransactionsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchSentTransactionsRPC.swift; sourceTree = "<group>"; };
+		77B69EAA224C3A5300DB4319 /* GetSentTransactionsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSentTransactionsRPC.swift; sourceTree = "<group>"; };
 		77CE359621F7DC76006ADABA /* TezosKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TezosKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE359F21F7DC76006ADABA /* TezosKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TezosKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE35A621F7DC76006ADABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -390,7 +390,7 @@
 				77B69EA3224C38C700DB4319 /* ConseilClient.swift */,
 				77B69EA6224C392300DB4319 /* ConseilPlatform.swift */,
 				77B69EA8224C39AC00DB4319 /* ConseilNetwork.swift */,
-				77B69EAA224C3A5300DB4319 /* FetchSentTransactionsRPC.swift */,
+				77B69EAA224C3A5300DB4319 /* GetSentTransactionsRPC.swift */,
 			);
 			path = Conseil;
 			sourceTree = "<group>";
@@ -878,7 +878,7 @@
 				77B69EA7224C392300DB4319 /* ConseilPlatform.swift in Sources */,
 				7794E97B224C2518000D9F1E /* Header.swift in Sources */,
 				77CE385921FC7ED8006ADABA /* Tez.swift in Sources */,
-				77B69EAB224C3A5300DB4319 /* FetchSentTransactionsRPC.swift in Sources */,
+				77B69EAB224C3A5300DB4319 /* GetSentTransactionsRPC.swift in Sources */,
 				77CE385F21FC7ED8006ADABA /* ContractCode.swift in Sources */,
 				77CE386821FC7ED8006ADABA /* ResponseAdapter.swift in Sources */,
 				77B1EADE222496B500EA4FCE /* TezosNodeClient+Promises.swift in Sources */,

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		77B1EB04222A0A6700EA4FCE /* SignedProtocolOperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EB03222A0A6700EA4FCE /* SignedProtocolOperationPayload.swift */; };
 		77B1EB06222A102500EA4FCE /* OperationWithCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EB05222A102500EA4FCE /* OperationWithCounter.swift */; };
 		77B1EB08222A179F00EA4FCE /* OperationWithCounterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EB07222A179F00EA4FCE /* OperationWithCounterTest.swift */; };
+		77B69EA4224C38C700DB4319 /* ConseilClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EA3224C38C700DB4319 /* ConseilClient.swift */; };
+		77B69EA7224C392300DB4319 /* ConseilPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EA6224C392300DB4319 /* ConseilPlatform.swift */; };
+		77B69EA9224C39AC00DB4319 /* ConseilNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EA8224C39AC00DB4319 /* ConseilNetwork.swift */; };
 		77CE36E021F7F49F006ADABA /* IntegerResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36B921F7F49C006ADABA /* IntegerResponseAdapterTest.swift */; };
 		77CE36E121F7F49F006ADABA /* RevealOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BA21F7F49C006ADABA /* RevealOperationTest.swift */; };
 		77CE36E221F7F49F006ADABA /* ForgeOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BB21F7F49C006ADABA /* ForgeOperationRPCTest.swift */; };
@@ -197,6 +200,9 @@
 		77B1EB03222A0A6700EA4FCE /* SignedProtocolOperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedProtocolOperationPayload.swift; sourceTree = "<group>"; };
 		77B1EB05222A102500EA4FCE /* OperationWithCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationWithCounter.swift; sourceTree = "<group>"; };
 		77B1EB07222A179F00EA4FCE /* OperationWithCounterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationWithCounterTest.swift; sourceTree = "<group>"; };
+		77B69EA3224C38C700DB4319 /* ConseilClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilClient.swift; sourceTree = "<group>"; };
+		77B69EA6224C392300DB4319 /* ConseilPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilPlatform.swift; sourceTree = "<group>"; };
+		77B69EA8224C39AC00DB4319 /* ConseilNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilNetwork.swift; sourceTree = "<group>"; };
 		77CE359621F7DC76006ADABA /* TezosKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TezosKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE359F21F7DC76006ADABA /* TezosKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TezosKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE35A621F7DC76006ADABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -376,6 +382,16 @@
 			path = Payload;
 			sourceTree = "<group>";
 		};
+		77B69EA5224C38CD00DB4319 /* Conseil */ = {
+			isa = PBXGroup;
+			children = (
+				77B69EA3224C38C700DB4319 /* ConseilClient.swift */,
+				77B69EA6224C392300DB4319 /* ConseilPlatform.swift */,
+				77B69EA8224C39AC00DB4319 /* ConseilNetwork.swift */,
+			);
+			path = Conseil;
+			sourceTree = "<group>";
+		};
 		77CE358C21F7DC76006ADABA = {
 			isa = PBXGroup;
 			children = (
@@ -431,6 +447,7 @@
 			children = (
 				77CE388021FC7EED006ADABA /* Info.plist */,
 				77CE387F21FC7EED006ADABA /* TezosKit.h */,
+				77B69EA5224C38CD00DB4319 /* Conseil */,
 				77DEB6E322373AFD00E4733D /* Core */,
 				77CE384421FC7ED8006ADABA /* Client */,
 				77CE380621FC7ED7006ADABA /* Operation */,
@@ -834,6 +851,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				77B69EA4224C38C700DB4319 /* ConseilClient.swift in Sources */,
 				77CE386B21FC7ED8006ADABA /* IntegerResponseAdapter.swift in Sources */,
 				77CE385B21FC7ED8006ADABA /* OperationMetadata.swift in Sources */,
 				77CE387A21FC7ED8006ADABA /* PreapplyOperationRPC.swift in Sources */,
@@ -851,8 +869,10 @@
 				77CE387B21FC7ED8006ADABA /* GetExpectedQuorumRPC.swift in Sources */,
 				77CE386F21FC7ED8006ADABA /* JSONArrayResponseAdapter.swift in Sources */,
 				77CE384E21FC7ED8006ADABA /* OperationKind.swift in Sources */,
+				77B69EA9224C39AC00DB4319 /* ConseilNetwork.swift in Sources */,
 				77CE386D21FC7ED8006ADABA /* PeriodKindResponseAdapter.swift in Sources */,
 				77CE386521FC7ED8006ADABA /* GetAddressCodeRPC.swift in Sources */,
+				77B69EA7224C392300DB4319 /* ConseilPlatform.swift in Sources */,
 				7794E97B224C2518000D9F1E /* Header.swift in Sources */,
 				77CE385921FC7ED8006ADABA /* Tez.swift in Sources */,
 				77CE385F21FC7ED8006ADABA /* ContractCode.swift in Sources */,

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		77B69EA4224C38C700DB4319 /* ConseilClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EA3224C38C700DB4319 /* ConseilClient.swift */; };
 		77B69EA7224C392300DB4319 /* ConseilPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EA6224C392300DB4319 /* ConseilPlatform.swift */; };
 		77B69EA9224C39AC00DB4319 /* ConseilNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EA8224C39AC00DB4319 /* ConseilNetwork.swift */; };
+		77B69EAB224C3A5300DB4319 /* FetchSentTransactionsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B69EAA224C3A5300DB4319 /* FetchSentTransactionsRPC.swift */; };
 		77CE36E021F7F49F006ADABA /* IntegerResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36B921F7F49C006ADABA /* IntegerResponseAdapterTest.swift */; };
 		77CE36E121F7F49F006ADABA /* RevealOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BA21F7F49C006ADABA /* RevealOperationTest.swift */; };
 		77CE36E221F7F49F006ADABA /* ForgeOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CE36BB21F7F49C006ADABA /* ForgeOperationRPCTest.swift */; };
@@ -203,6 +204,7 @@
 		77B69EA3224C38C700DB4319 /* ConseilClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilClient.swift; sourceTree = "<group>"; };
 		77B69EA6224C392300DB4319 /* ConseilPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilPlatform.swift; sourceTree = "<group>"; };
 		77B69EA8224C39AC00DB4319 /* ConseilNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilNetwork.swift; sourceTree = "<group>"; };
+		77B69EAA224C3A5300DB4319 /* FetchSentTransactionsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchSentTransactionsRPC.swift; sourceTree = "<group>"; };
 		77CE359621F7DC76006ADABA /* TezosKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TezosKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE359F21F7DC76006ADABA /* TezosKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TezosKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		77CE35A621F7DC76006ADABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -388,6 +390,7 @@
 				77B69EA3224C38C700DB4319 /* ConseilClient.swift */,
 				77B69EA6224C392300DB4319 /* ConseilPlatform.swift */,
 				77B69EA8224C39AC00DB4319 /* ConseilNetwork.swift */,
+				77B69EAA224C3A5300DB4319 /* FetchSentTransactionsRPC.swift */,
 			);
 			path = Conseil;
 			sourceTree = "<group>";
@@ -875,6 +878,7 @@
 				77B69EA7224C392300DB4319 /* ConseilPlatform.swift in Sources */,
 				7794E97B224C2518000D9F1E /* Header.swift in Sources */,
 				77CE385921FC7ED8006ADABA /* Tez.swift in Sources */,
+				77B69EAB224C3A5300DB4319 /* FetchSentTransactionsRPC.swift in Sources */,
 				77CE385F21FC7ED8006ADABA /* ContractCode.swift in Sources */,
 				77CE386821FC7ED8006ADABA /* ResponseAdapter.swift in Sources */,
 				77B1EADE222496B500EA4FCE /* TezosNodeClient+Promises.swift in Sources */,

--- a/TezosKit/Client/AbstractClient.swift
+++ b/TezosKit/Client/AbstractClient.swift
@@ -15,7 +15,7 @@ public class AbstractClient {
   private let responseHandler: RPCResponseHandler
 
   /// The queue that callbacks from requests will be made on.
-  private let callbackQueue: DispatchQueue
+  internal let callbackQueue: DispatchQueue
 
   /// Initialize a new AbstractNetworkClient.
   /// - Parameters:

--- a/TezosKit/Conseil/ConseilClient.swift
+++ b/TezosKit/Conseil/ConseilClient.swift
@@ -57,13 +57,18 @@ public class ConseilClient: AbstractClient {
     limit: Int = 100,
     completion: @escaping (Result<[[String: Any]], TezosKitError>) -> Void
   ) {
-    let rpc = ConseilFetchSentTransactionRPC(
+    guard let rpc = GetSentTransactionsRPC(
       account: account,
       limit: limit,
       apiKey: apiKey,
       platform: platform,
       network: network
-    )
+    ) else {
+      self.callbackQueue.async {
+        completion(.failure(TezosKitError(kind: .invalidURL, underlyingError: nil)))
+      }
+      return
+    }
     send(rpc, completion: completion)
   }
 }

--- a/TezosKit/Conseil/ConseilClient.swift
+++ b/TezosKit/Conseil/ConseilClient.swift
@@ -1,0 +1,121 @@
+// Copyright Keefer Taylor, 2019
+
+/// Conseil Client is a WIP.
+/// Remaining Work:
+/// - Promises
+/// - Extensions
+/// - Updating documentation
+
+/// A client for a Conseil Server.
+public class ConseilClient: AbstractClient {
+  /// The platfom that this client will query.
+  private let platform: ConseilPlatform
+
+  /// The network that this client will query.
+  private let network: ConseilNetwork
+
+  /// Initialize a new client for a Conseil Service.
+  /// - Parameters:
+  ///   - remoteNodeURL: The path to the remote node.
+  ///   - platform: The platform to query, defaults to tezos.
+  ///   - network: The network to query, defaults to mainnet.
+  ///   - urlSession: The URLSession that will manage network requests, defaults to the shared session.
+  ///   - callbackQueue: A dispatch queue that callbacks will be made on, defaults to the main queue.
+  public init(
+    remoteNodeURL: URL,
+    urlSession: URLSession = URLSession.shared,
+    callbackQueue: DispatchQueue = DispatchQueue.main,
+    platform: ConseilPlatform = .tezos,
+    network: ConseilNetwork = .mainnet
+    ) {
+    self.platform = platform
+    self.network = network
+    super.init(
+      remoteNodeURL: remoteNodeURL,
+      urlSession: urlSession,
+      callbackQueue: callbackQueue,
+      responseHandler: RPCResponseHandler()
+    )
+  }
+
+  /// Retrieve transactions from an account.
+  public func operations(for account: String, completion: (Result<[[String: Any]]> -> Void)) {
+    let rpc = ConseilTransactionQuery(platform: platform, network: network))
+    send(rpc, completion)
+  }
+}
+
+private enum Params {
+  public static let fields = "fields"
+  public enum Fields {
+    public static let amount = "amount"
+    public static let destination = "destination"
+    public static let fee = "fee"
+    public static let kind = "kind"
+    public static let source = "source"
+    public static let timestamp = "timestamp"
+  }
+
+  public static let predicates = "predicates"
+  public enum Predicate {
+    public static let field = "field"
+    public static let operation = "operation"
+    public static let set = "set"
+  }
+
+  public static let orderBy = "orderBy"
+  public static let limit = "limit"
+
+}
+
+private enum Query {
+  public static let fields = "fields"
+  public static let predicates = "predicates"
+  public static let orderBy = "orderBy"
+  public static let limit = "limit"
+}
+
+
+
+
+private enum Kind {
+  public let transaction = "transaction"
+}
+
+private enum Operation {
+  public let equal = "eq"
+}
+
+private enum OrderBy {
+  public static let field = "field"
+  public static let direction = "direction"
+}
+
+public class ConseilTransactionQuery {
+  public init(source: String, limit: Int, platform: ConseilPlatform, network: ConseilNetwork) {
+    let url = "/v2/data/" + platform.rawValue + "/" + network.rawValue + "/operations"
+
+    // TODO: refactor these to be an enum.
+    let fields = [ "timestamp", "source", "destination", "amount", "fee"]
+
+    let predicateDict = [
+      "field": "kind",
+      "set": [ "transaction" ],
+      "operation": "eq"
+    ]
+
+    let predicates = []
+    let payloadDict = {
+      "fields": fields
+      "predicates": predicates
+    }
+
+
+    // TODO: Refactor to a dictionary.
+    let payload = "{\"fields\": [\"timestamp\", \"source\", \"destination\", \"amount\", \"fee\"],\"predicates\": [{\"field\": \"kind\", \"set\": [\"transaction\"], \"operation\": \"eq\"}, {\"field\": \"source\", \"set\": [\"%s\"], \"operation\": \"eq\"}],\"orderBy\": [{\"field\": \"timestamp\", \"direction\": \"desc\"}],\"limit\": 100}"
+  }
+}
+
+/// TODOs:
+/// - Promises Extension
+/// - Integration Tests

--- a/TezosKit/Conseil/ConseilNetwork.swift
+++ b/TezosKit/Conseil/ConseilNetwork.swift
@@ -1,0 +1,8 @@
+// Copyright Keefer Taylor, 2019
+
+/// Networks supported by Conseil.
+public enum ConseilNetwork: String {
+  case zeronet
+  case alphanet
+  case mainnet
+}

--- a/TezosKit/Conseil/ConseilPlatform.swift
+++ b/TezosKit/Conseil/ConseilPlatform.swift
@@ -1,0 +1,6 @@
+// Copyright Keefer Taylor, 2019.
+
+/// Platforms supported by Conseil.
+public enum ConseilPlatform: String {
+  case tezos
+}

--- a/TezosKit/Conseil/FetchSentTransactionsRPC.swift
+++ b/TezosKit/Conseil/FetchSentTransactionsRPC.swift
@@ -16,7 +16,7 @@ public class ConseilFetchSentTransactionRPC: RPC<[[String: Any]]> {
       Header.contentTypeApplicationJSON,
       Header(field: "apiKey", value: apiKey)
     ]
-    let payload = "{\"fields\": [\"timestamp\", \"source\", \"destination\", \"amount\", \"fee\"],\"predicates\": [{\"field\": \"kind\",\"set\": [\"transaction\"],\"operation\": \"eq\",\"inverse\": false}, {\"field\": \"source\",\"set\": [\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\"],\"operation\": \"eq\",\"inverse\": false}],\"orderBy\": [{\"field\": \"timestamp\",\"direction\": \"desc\"}],\"limit\": 100}"
+    let payload = "{\"fields\": [\"timestamp\", \"source\", \"destination\", \"amount\", \"fee\"],\"predicates\": [{\"field\": \"kind\",\"set\": [\"transaction\"],\"operation\": \"eq\",\"inverse\": false}, {\"field\": \"source\",\"set\": [\"\(account)\"],\"operation\": \"eq\",\"inverse\": false}],\"orderBy\": [{\"field\": \"timestamp\",\"direction\": \"desc\"}],\"limit\": \(limit)}"
 
     super.init(
       endpoint: endpoint,

--- a/TezosKit/Conseil/FetchSentTransactionsRPC.swift
+++ b/TezosKit/Conseil/FetchSentTransactionsRPC.swift
@@ -1,0 +1,18 @@
+// Copyright Keefer Taylor, 2019.
+
+/// An RPC which fetches sent transactions from an account.
+public class ConseilFetchSentTransaction: RPC<[[String: Any]]> {
+  public init(account: String, apiKey: String) {
+    let headers = [
+      Header.contentTypeApplicationJSON,
+      Header(field: "apiKey", value: apiKey)
+    ]
+
+    super.init(
+      endpoint: endpoint,
+      headers: headers,
+      responseAdapterClass: JSONArrayResponseAdapter.Self,
+      payload: payload
+    )
+  }
+}

--- a/TezosKit/Conseil/FetchSentTransactionsRPC.swift
+++ b/TezosKit/Conseil/FetchSentTransactionsRPC.swift
@@ -16,7 +16,9 @@ public class ConseilFetchSentTransactionRPC: RPC<[[String: Any]]> {
       Header.contentTypeApplicationJSON,
       Header(field: "apiKey", value: apiKey)
     ]
-    let payload = "{\"fields\": [\"timestamp\", \"source\", \"destination\", \"amount\", \"fee\"],\"predicates\": [{\"field\": \"kind\",\"set\": [\"transaction\"],\"operation\": \"eq\",\"inverse\": false}, {\"field\": \"source\",\"set\": [\"\(account)\"],\"operation\": \"eq\",\"inverse\": false}],\"orderBy\": [{\"field\": \"timestamp\",\"direction\": \"desc\"}],\"limit\": \(limit)}"
+    let payload = """
+      {"fields": [],"predicates": [{"field": "kind","set": ["transaction"],"operation": "eq","inverse": false}, {"field": "source","set": ["\(account)"],"operation": "eq","inverse": false}],"orderBy": [{"field": "timestamp","direction": "desc"}],"limit": \(limit)}
+    """
 
     super.init(
       endpoint: endpoint,

--- a/TezosKit/Conseil/FetchSentTransactionsRPC.swift
+++ b/TezosKit/Conseil/FetchSentTransactionsRPC.swift
@@ -1,17 +1,27 @@
 // Copyright Keefer Taylor, 2019.
 
+// swiftlint:disable line_length
+
 /// An RPC which fetches sent transactions from an account.
-public class ConseilFetchSentTransaction: RPC<[[String: Any]]> {
-  public init(account: String, apiKey: String) {
+public class ConseilFetchSentTransactionRPC: RPC<[[String: Any]]> {
+  /// - Parameters:
+  ///   - account: The account to query.
+  ///   - limit: The number of items to return.
+  ///   - apiKey: The API key to send in the request headers.
+  ///   - platform: The platform to query.
+  ///   - network: The network to query.
+  public init(account: String, limit: Int, apiKey: String, platform: ConseilPlatform, network: ConseilNetwork) {
+    let endpoint = "/v2/data/" + platform.rawValue + "/" + network.rawValue + "/operations"
     let headers = [
       Header.contentTypeApplicationJSON,
       Header(field: "apiKey", value: apiKey)
     ]
+    let payload = "{\"fields\": [\"timestamp\", \"source\", \"destination\", \"amount\", \"fee\"],\"predicates\": [{\"field\": \"kind\",\"set\": [\"transaction\"],\"operation\": \"eq\",\"inverse\": false}, {\"field\": \"source\",\"set\": [\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\"],\"operation\": \"eq\",\"inverse\": false}],\"orderBy\": [{\"field\": \"timestamp\",\"direction\": \"desc\"}],\"limit\": 100}"
 
     super.init(
       endpoint: endpoint,
       headers: headers,
-      responseAdapterClass: JSONArrayResponseAdapter.Self,
+      responseAdapterClass: JSONArrayResponseAdapter.self,
       payload: payload
     )
   }

--- a/TezosKit/Conseil/GetSentTransactionsRPC.swift
+++ b/TezosKit/Conseil/GetSentTransactionsRPC.swift
@@ -10,8 +10,16 @@ public class GetSentTransactionsRPC: RPC<[[String: Any]]> {
   ///   - apiKey: The API key to send in the request headers.
   ///   - platform: The platform to query.
   ///   - network: The network to query.
-  public init(account: String, limit: Int, apiKey: String, platform: ConseilPlatform, network: ConseilNetwork) {
-    let endpoint = "/v2/data/" + platform.rawValue + "/" + network.rawValue + "/operations"
+  public init?(account: String, limit: Int, apiKey: String, platform: ConseilPlatform, network: ConseilNetwork) {
+    guard let escapedPlatform = platform.rawValue.addingPercentEncoding(
+                withAllowedCharacters: CharacterSet.urlQueryAllowed
+          ),
+          let escapedNetwork = network.rawValue.addingPercentEncoding(
+                withAllowedCharacters: CharacterSet.urlQueryAllowed
+      ) else {
+        return nil
+    }
+    let endpoint = "/v2/data/\(escapedPlatform)/\(escapedNetwork)/operations"
     let headers = [
       Header.contentTypeApplicationJSON,
       Header(field: "apiKey", value: apiKey)

--- a/TezosKit/Conseil/GetSentTransactionsRPC.swift
+++ b/TezosKit/Conseil/GetSentTransactionsRPC.swift
@@ -3,7 +3,7 @@
 // swiftlint:disable line_length
 
 /// An RPC which fetches sent transactions from an account.
-public class ConseilFetchSentTransactionRPC: RPC<[[String: Any]]> {
+public class GetSentTransactionsRPC: RPC<[[String: Any]]> {
   /// - Parameters:
   ///   - account: The account to query.
   ///   - limit: The number of items to return.


### PR DESCRIPTION
Initial commit of Conseil support. 

Wires a client to a single RPC. 

Future Work:
- Support for query parameters
- First class response objects
- Promises Extension
- Integration Tests
- Updating documentation

Addresses #2 