### PR TITLE
Utilize BigInt in Tez

### DIFF
--- a/Tests/TezosKit/TezTest.swift
+++ b/Tests/TezosKit/TezTest.swift
@@ -105,4 +105,15 @@ class TezTest: XCTestCase {
     XCTAssertEqual(threeFiftyAsString, threeFiftyAsDecimal)
     XCTAssertNotEqual(threeFiftyAsDecimal, fourAsDecimal)
   }
+
+  public func testVeryLargeAmout() {
+    guard let oneQuadrillionAsString = Tez("1000000000000000000000") else {
+      XCTFail()
+      return
+    }
+
+    let oneQuadrillionAsDecimal = Tez(1_000_000_000_000_000)
+
+    XCTAssertEqual(oneQuadrillionAsString, oneQuadrillionAsDecimal)
+  }
 }

--- a/TezosKit/Models/Tez.swift
+++ b/TezosKit/Models/Tez.swift
@@ -1,5 +1,6 @@
 // Copyright Keefer Taylor, 2018
 
+import BigInt
 import Foundation
 
 /// A model class representing a positive floating point amounty of Tez.
@@ -44,14 +45,14 @@ public struct Tez {
    * is dropped.
    */
   public init(_ balance: Double) {
-    let integerValue = Int(balance)
+    let integerValue = BigInt(balance)
 
     // Convert decimalDigitCount significant digits of decimals into integers to avoid having to
     // deal with decimals.
     let multiplierDoubleValue = (pow(10, decimalDigitCount) as NSDecimalNumber).doubleValue
     let multiplierIntValue = (pow(10, decimalDigitCount) as NSDecimalNumber).intValue
-    let significantDecimalDigitsAsInteger = Int(balance * multiplierDoubleValue)
-    let significantIntegerDigitsAsInteger = integerValue * multiplierIntValue
+    let significantDecimalDigitsAsInteger = BigInt(balance * multiplierDoubleValue)
+    let significantIntegerDigitsAsInteger = BigInt(integerValue * BigInt(multiplierIntValue))
     let decimalValue = significantDecimalDigitsAsInteger - significantIntegerDigitsAsInteger
 
     integerAmount = String(integerValue)

--- a/TezosKit/Models/Tez.swift
+++ b/TezosKit/Models/Tez.swift
@@ -11,39 +11,28 @@ public struct Tez {
   /// The number of decimal places available in Tezos values.
   private let decimalDigitCount = 6
 
-  /**
-   * A string representing the integer amount of the balance.
-   * For instance, a balance of 123.456 would be represented in this field as "123".
-   */
+  /// A string representing the integer amount of the balance.
+  /// For instance, a balance of 123.456 would be represented in this field as "123".
   private let integerAmount: String
 
-  /**
-   * A string representing the decimal amount of the balance.
-   * For instance, a balance of 123.456 would be represented in this field as "456".
-   */
+  /// A string representing the decimal amount of the balance.
+  /// For instance, a balance of 123.456 would be represented in this field as "456".
   private let decimalAmount: String
 
-  /**
-   * A human readable representation of the given balance.
-   */
+  /// A human readable representation of the given balance.
   public var humanReadableRepresentation: String {
     return integerAmount + "." + decimalAmount
   }
 
-  /**
-   * A representation of the given balance for use in RPC requests.
-   */
+  /// A representation of the given balance for use in RPC requests.
   public var rpcRepresentation: String {
     // Trim any leading zeroes by converting to an Int.
     return (integerAmount + decimalAmount).replacingOccurrences(of: "^0+", with: "", options: .regularExpression)
   }
 
-  /**
-   * Initialize a new balance from a given decimal number.
-   *
-   * - Warning: Balances are accurate up to |decimalDigitCount| decimal places. Additional precision
-   * is dropped.
-   */
+  /// Initialize a new balance from a given decimal number.
+  ///
+  /// - Warning: Balances are accurate up to |decimalDigitCount| decimal places. Additional precision is dropped.
   public init(_ balance: Double) {
     let integerValue = BigInt(balance)
 
@@ -67,9 +56,7 @@ public struct Tez {
     decimalAmount = paddedDecimalAmount
   }
 
-  /**
-   * Initialize a new balance from an RPC representation of a balance.
-   */
+  /// Initialize a new balance from an RPC representation of a balance.
   public init?(_ balance: String) {
     // Make sure the given string only contains digits.
     guard CharacterSet.decimalDigits.isSuperset(of: CharacterSet(charactersIn: balance)) else {


### PR DESCRIPTION
Prevents crashing exceptions when we overflow ints. 