### PR TITLE
More fixes for Conseil

### DIFF
--- a/IntegrationTests/Extensions/PromiseKit/ConseilClientIntegrationTests+Promises.swift
+++ b/IntegrationTests/Extensions/PromiseKit/ConseilClientIntegrationTests+Promises.swift
@@ -13,6 +13,7 @@ extension ConseilClientIntegrationTests {
 
     conseilClient.transactionsReceived(from: Wallet.testWallet.address).done { result in
       XCTAssertNotNil(result)
+      XCTAssert(result.count > 1)
       expectation.fulfill()
     } .catch { _ in
       XCTFail()
@@ -26,6 +27,7 @@ extension ConseilClientIntegrationTests {
 
     conseilClient.transactionsSent(from: Wallet.testWallet.address).done { result in
       XCTAssertNotNil(result)
+      XCTAssert(result.count > 1)
       expectation.fulfill()
     } .catch { _ in
       XCTFail()
@@ -39,6 +41,7 @@ extension ConseilClientIntegrationTests {
 
     conseilClient.transactions(from: Wallet.testWallet.address).done { result in
       XCTAssertNotNil(result)
+      XCTAssert(result.count > 1)
       expectation.fulfill()
       } .catch { _ in
         XCTFail()
@@ -51,6 +54,7 @@ extension ConseilClientIntegrationTests {
     let expectation = XCTestExpectation(description: "promise fulfilled")
     conseilClient.originatedAccounts(from: Wallet.testWallet.address).done { result in
       XCTAssertNotNil(result)
+      XCTAssert(result.count > 1)
       expectation.fulfill()
       } .catch { _ in
         XCTFail()

--- a/IntegrationTests/TezosKit/ConseilClientIntegrationTests.swift
+++ b/IntegrationTests/TezosKit/ConseilClientIntegrationTests.swift
@@ -28,7 +28,8 @@ class ConseilClientIntegrationTests: XCTestCase {
     let expectation = XCTestExpectation(description: "completion called")
     conseilClient.transactionsSent(from: Wallet.testWallet.address) { result in
       switch result {
-      case .success:
+      case .success(let results):
+        XCTAssert(results.count > 1)
         expectation.fulfill()
       case .failure:
         XCTFail()
@@ -41,7 +42,8 @@ class ConseilClientIntegrationTests: XCTestCase {
     let expectation = XCTestExpectation(description: "completion called")
     conseilClient.transactionsReceived(from: Wallet.testWallet.address) { result in
       switch result {
-      case .success:
+      case .success(let results):
+        XCTAssert(results.count > 1)
         expectation.fulfill()
       case .failure:
         XCTFail()
@@ -54,7 +56,8 @@ class ConseilClientIntegrationTests: XCTestCase {
     let expectation = XCTestExpectation(description: "completion called")
     conseilClient.transactions(from: Wallet.testWallet.address) { result in
       switch result {
-      case .success:
+      case .success(let results):
+        XCTAssert(results.count > 1)
         expectation.fulfill()
       case .failure:
         XCTFail()
@@ -67,9 +70,11 @@ class ConseilClientIntegrationTests: XCTestCase {
     let expectation = XCTestExpectation(description: "completion called")
     conseilClient.originatedAccounts(from: Wallet.testWallet.address) { result in
       switch result {
-      case .success:
+      case .success(let results):
+        XCTAssert(results.count > 1)
         expectation.fulfill()
-      case .failure:
+      case .failure(let error):
+        print(error)
         XCTFail()
       }
     }

--- a/TezosKit/Conseil/ConseilQuery.swift
+++ b/TezosKit/Conseil/ConseilQuery.swift
@@ -14,24 +14,37 @@ public enum ConseilQuery: String {
     case field
     case operation
     public enum Operation: String {
+      case after = "after"
+      case before
+      case between
+      case endsWith
       case equal = "eq"
+      case greaterThan = "gt"
+      case `in` = "in"
+      case isNull = "isnull"
+      case lessThan = "lt"
+      case like
+      case startsWith
     }
     case inverse
 
     public static func predicateWith(
       field: String,
-      set: [String],
       operation: ConseilQuery.Predicates.Operation = .equal,
+      set: [String] = [],
       inverse: Bool = false
     ) -> ConseilPredicate {
-      return [
+      var predicate: [String: Any] = [
         ConseilQuery.Predicates.field.rawValue: field,
-        ConseilQuery.Predicates.set.rawValue: set,
         ConseilQuery.Predicates.operation.rawValue: operation.rawValue,
-        ConseilQuery.Predicates.inverse.rawValue: inverse
+        ConseilQuery.Predicates.inverse.rawValue: inverse,
+        ConseilQuery.Predicates.set.rawValue: set
       ]
+      return predicate
     }
   }
+
+  case aggregation
 
   case orderBy = "orderby"
   public enum OrderBy: String {

--- a/TezosKit/Conseil/ConseilQuery.swift
+++ b/TezosKit/Conseil/ConseilQuery.swift
@@ -34,13 +34,12 @@ public enum ConseilQuery: String {
       set: [String] = [],
       inverse: Bool = false
     ) -> ConseilPredicate {
-      var predicate: [String: Any] = [
+      return [
         ConseilQuery.Predicates.field.rawValue: field,
         ConseilQuery.Predicates.operation.rawValue: operation.rawValue,
         ConseilQuery.Predicates.inverse.rawValue: inverse,
         ConseilQuery.Predicates.set.rawValue: set
       ]
-      return predicate
     }
   }
 

--- a/TezosKit/Conseil/GetOriginatedAccountsRPC.swift
+++ b/TezosKit/Conseil/GetOriginatedAccountsRPC.swift
@@ -7,7 +7,12 @@ public class GetOriginatedAccounts: ConseilQueryRPC<[[String: Any]]> {
   ///   - limit: The number of items to return.
   public init(account: String, limit: Int) {
     let predicates: [ConseilPredicate] = [
-      ConseilQuery.Predicates.predicateWith(field: "manager", set: [account])
+      ConseilQuery.Predicates.predicateWith(field: "manager", set: [account]),
+      ConseilQuery.Predicates.predicateWith(
+        field: "script",
+        operation: ConseilQuery.Predicates.Operation.isNull,
+        inverse: false
+      )
     ]
     let orderBy: ConseilOrderBy = ConseilQuery.OrderBy.orderBy(field: "block_level")
     let query: [String: Any] = ConseilQuery.query(predicates: predicates, orderBy: orderBy, limit: limit)


### PR DESCRIPTION
Fixes include:
- Strongly typed unit tests
- Filter originated accounts to only accounts, not contracts
- Support for additional operations