### PR TITLE
Migrate to Operation Factory

### DIFF
--- a/Extensions/PromiseKit/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNodeClient+Promises.swift
@@ -68,7 +68,7 @@ extension TezosNodeClient {
     parameters: [String: Any]? = nil,
     operationFees: OperationFees? = nil
   ) -> Promise<String> {
-    let transactionOperation = TransactionOperation(
+    let transactionOperation = operationFactory.transactionOperation(
       amount: amount,
       source: source,
       destination: recipientAddress,
@@ -100,7 +100,11 @@ extension TezosNodeClient {
     keys: Keys,
     operationFees: OperationFees? = nil
   ) -> Promise<String> {
-    let delegationOperation = DelegationOperation.delegateOperation(source: source, to: delegate)
+    let delegationOperation = operationFactory.delegateOperation(
+      source: source,
+      to: delegate,
+      operationFees: operationFees
+    )
     return forgeSignPreapplyAndInject(
       operation: delegationOperation,
       source: source,
@@ -119,7 +123,10 @@ extension TezosNodeClient {
     keys: Keys,
     operationFees: OperationFees? = nil
   ) -> Promise<String> {
-    let undelegateOperatoin = DelegationOperation.undelegateOperation(source: source, operationFees: operationFees)
+    let undelegateOperatoin = operationFactory.undelegateOperation(
+      source: source,
+      operationFees: operationFees
+    )
     return forgeSignPreapplyAndInject(
       operation: undelegateOperatoin,
       source: source,
@@ -138,7 +145,7 @@ extension TezosNodeClient {
     keys: Keys,
     operationFees: OperationFees? = nil
   ) -> Promise<String> {
-    let registerDelegateOperation = DelegationOperation.registerDelegateOperation(
+    let registerDelegateOperation = operationFactory.registerDelegateOperation(
       source: delegate,
       operationFees: operationFees
     )
@@ -163,7 +170,7 @@ extension TezosNodeClient {
     operationFees: OperationFees? = nil
   ) -> Promise<String> {
     let originateAccountOperation =
-      OriginateAccountOperation(address: managerAddress, contractCode: contractCode, operationFees: operationFees)
+      operationFactory.originateOperation(address: managerAddress, contractCode: contractCode, operationFees: operationFees)
     return forgeSignPreapplyAndInject(
       operation: originateAccountOperation,
       source: managerAddress,

--- a/IntegrationTests/Extensions/PromiseKit/TezosNodeIntegrationTests+Promises.swift
+++ b/IntegrationTests/Extensions/PromiseKit/TezosNodeIntegrationTests+Promises.swift
@@ -154,7 +154,7 @@ extension TezosNodeIntegrationTests {
   public func testRunOperation_promises() {
     let expectation = XCTestExpectation(description: "completion called")
 
-    let operation = OriginateAccountOperation(wallet: .testWallet)
+    let operation = OperationFactory.defaultFactory.originateOperation(address: Wallet.testWallet.address)
     nodeClient.runOperation(operation, from: .testWallet) .done { result in
       guard let contents = result["contents"] as? [[String: Any]],
             let metadata = contents[0]["metadata"] as? [String: Any],
@@ -200,14 +200,14 @@ extension TezosNodeIntegrationTests {
     let expectation = XCTestExpectation(description: "promise fulfilled")
 
     let ops: [TezosKit.Operation] = [
-      TransactionOperation(
+      OperationFactory.defaultFactory.transactionOperation(
         amount: Tez("1")!,
-        source: .testWallet,
+        source: Wallet.testWallet.address,
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5"
       ),
-      TransactionOperation(
+      OperationFactory.defaultFactory.transactionOperation(
         amount: Tez("2")!,
-        source: .testWallet,
+        source: Wallet.testWallet.address,
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5"
       )
     ]

--- a/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
+++ b/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
@@ -46,6 +46,10 @@ extension UInt32 {
   public static let blockTime: UInt32 = 120
 }
 
+extension OperationFactory {
+  public static let defaultFactory = OperationFactory()
+}
+
 class TezosNodeIntegrationTests: XCTestCase {
   public var nodeClient = TezosNodeClient()
 
@@ -258,7 +262,7 @@ class TezosNodeIntegrationTests: XCTestCase {
   public func testRunOperation() {
     let expectation = XCTestExpectation(description: "completion called")
 
-    let operation = OriginateAccountOperation(wallet: .testWallet)
+    let operation = OperationFactory.defaultFactory.originateOperation(address: Wallet.testWallet.address)
     self.nodeClient.runOperation(operation, from: .testWallet) { result in
       switch result {
       case .failure:
@@ -283,14 +287,14 @@ class TezosNodeIntegrationTests: XCTestCase {
     let expectation = XCTestExpectation(description: "completion called")
 
     let ops: [TezosKit.Operation] = [
-      TransactionOperation(
+      OperationFactory.defaultFactory.transactionOperation(
         amount: Tez("1")!,
-        source: .testWallet,
+        source: Wallet.testWallet.address,
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5"
       ),
-      TransactionOperation(
+      OperationFactory.defaultFactory.transactionOperation(
         amount: Tez("2")!,
-        source: .testWallet,
+        source: Wallet.testWallet.address,
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5"
       )
     ]

--- a/Tests/TestObjects.swift
+++ b/Tests/TestObjects.swift
@@ -53,7 +53,11 @@ extension SignedProtocolOperationPayload {
 }
 
 extension AbstractOperation {
-  public static let testOperation = AbstractOperation(source: .testAddress, kind: .reveal)
+  public static let testOperation = AbstractOperation(
+    source: .testAddress,
+    kind: .reveal,
+    operationFees: OperationFees.testFees
+  )
 }
 
 extension OperationWithCounter {
@@ -75,5 +79,17 @@ extension Transaction {
     operationGroupHash: "opMiJzXJV8nKWy7VTLh2yxFL8yUGDpVkvnbA5hUwj9dSnpMEEMa",
     operationID: 1_511_646,
     parameters: nil
+  )
+}
+
+extension OperationFactory {
+  public static let testFactory = OperationFactory()
+}
+
+extension OperationFees {
+  public static let testFees = OperationFees(
+    fee: Tez.zeroBalance,
+    gasLimit: Tez.zeroBalance,
+    storageLimit: Tez.zeroBalance
   )
 }

--- a/Tests/TezosKit/AbstractOperationTest.swift
+++ b/Tests/TezosKit/AbstractOperationTest.swift
@@ -5,10 +5,18 @@ import XCTest
 
 class AbstractOperationTest: XCTestCase {
   public func testRequiresReveal() {
-    let abstractOperationRequiringReveal = AbstractOperation(source: "tz1abc", kind: .delegation)
+    let abstractOperationRequiringReveal = AbstractOperation(
+      source: "tz1abc",
+      kind: .delegation,
+      operationFees: OperationFees.testFees
+    )
     XCTAssertTrue(abstractOperationRequiringReveal.requiresReveal)
 
-    let abstractOperationNotRequiringReveal = AbstractOperation(source: "tz1abc", kind: .reveal)
+    let abstractOperationNotRequiringReveal = AbstractOperation(
+      source: "tz1abc",
+      kind: .reveal,
+      operationFees: OperationFees.testFees
+    )
     XCTAssertFalse(abstractOperationNotRequiringReveal.requiresReveal)
   }
 

--- a/Tests/TezosKit/DelegationOperationTest.swift
+++ b/Tests/TezosKit/DelegationOperationTest.swift
@@ -8,7 +8,7 @@ class DelegationOperationTest: XCTestCase {
     let source = "tz1abc"
     let delegate = "tz1def"
 
-    let operation = DelegationOperation.delegateOperation(source: source, to: delegate)
+    let operation = OperationFactory.testFactory.delegateOperation(source: source, to: delegate)
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])
@@ -21,7 +21,7 @@ class DelegationOperationTest: XCTestCase {
   public func testDictionaryRepresentation_undelegate() {
     let source = "tz1abc"
 
-    let operation = DelegationOperation.undelegateOperation(source: source)
+    let operation = OperationFactory.testFactory.undelegateOperation(source: source)
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])
@@ -33,7 +33,7 @@ class DelegationOperationTest: XCTestCase {
   public func testDictionaryRepresentation_registerDelegate() {
     let source = "tz1abc"
 
-    let operation = DelegationOperation.registerDelegateOperation(source: source)
+    let operation = OperationFactory.testFactory.registerDelegateOperation(source: source)
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])

--- a/Tests/TezosKit/OriginateAccountOperation.swift
+++ b/Tests/TezosKit/OriginateAccountOperation.swift
@@ -3,30 +3,14 @@
 import TezosKit
 import XCTest
 
-class OriginateAccountOperationTest: XCTestCase {
+class OriginationOperation: XCTestCase {
   public func testDictionaryRepresentation() {
     let address = "tz1abc123"
-    let operation = OriginateAccountOperation(address: address)
+    let operation = OperationFactory.testFactory.originateOperation(address: address)
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["manager_pubkey"])
     XCTAssertEqual(dictionary["manager_pubkey"] as? String, address)
-
-    XCTAssertNotNil(dictionary["balance"])
-    XCTAssertEqual(dictionary["balance"] as? String, "0")
-  }
-
-  public func testDictionaryRepresentationFromWallet() {
-    guard let wallet = Wallet() else {
-      XCTFail()
-      return
-    }
-
-    let operation = OriginateAccountOperation(wallet: wallet)
-    let dictionary = operation.dictionaryRepresentation
-
-    XCTAssertNotNil(dictionary["manager_pubkey"])
-    XCTAssertEqual(dictionary["manager_pubkey"] as? String, wallet.address)
 
     XCTAssertNotNil(dictionary["balance"])
     XCTAssertEqual(dictionary["balance"] as? String, "0")

--- a/Tests/TezosKit/RevealOperationTest.swift
+++ b/Tests/TezosKit/RevealOperationTest.swift
@@ -8,7 +8,7 @@ class RevealOperationTest: XCTestCase {
     let source = "tz1abc"
     let publicKey = FakePublicKey(base58CheckRepresentation: "edpkXYZ")
 
-    let operation = RevealOperation(from: source, publicKey: publicKey)
+    let operation = OperationFactory.testFactory.revealOperation(from: source, publicKey: publicKey)
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])
@@ -16,21 +16,5 @@ class RevealOperationTest: XCTestCase {
 
     XCTAssertNotNil(dictionary["public_key"])
     XCTAssertEqual(dictionary["public_key"] as? String, publicKey.base58CheckRepresentation)
-  }
-
-  public func testDictionaryRepresentationFromWallet() {
-    guard let wallet = Wallet() else {
-      XCTFail()
-      return
-    }
-
-    let operation = RevealOperation(from: wallet)
-    let dictionary = operation.dictionaryRepresentation
-
-    XCTAssertNotNil(dictionary["source"])
-    XCTAssertEqual(dictionary["source"] as? String, wallet.address)
-
-    XCTAssertNotNil(dictionary["public_key"])
-    XCTAssertEqual(dictionary["public_key"] as? String, wallet.keys.publicKey.base58CheckRepresentation)
   }
 }

--- a/Tests/TezosKit/TransactionOperationTest.swift
+++ b/Tests/TezosKit/TransactionOperationTest.swift
@@ -10,7 +10,11 @@ class TransactionOperationTest: XCTestCase {
   public func testTransation() {
     let source = "tz1abc"
 
-    let operation = TransactionOperation(amount: balance, source: source, destination: destination)
+    let operation = OperationFactory.testFactory.transactionOperation(
+      amount: balance,
+      source: source,
+      destination: destination
+    )
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])
@@ -29,7 +33,11 @@ class TransactionOperationTest: XCTestCase {
       return
     }
 
-    let operation = TransactionOperation(amount: balance, source: wallet, destination: destination)
+    let operation = OperationFactory.testFactory.transactionOperation(
+      amount: balance,
+      source: wallet.address,
+      destination: destination
+    )
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		7776493B227616B200451DD5 /* FakeObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7776493A227616B200451DD5 /* FakeObjects.swift */; };
 		779427A722BABB2700559A03 /* DefaultFeeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779427A622BABB2700559A03 /* DefaultFeeProvider.swift */; };
 		779427A922BABB8E00559A03 /* TezosProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779427A822BABB8E00559A03 /* TezosProtocol.swift */; };
+		779427AB22BABE5900559A03 /* OperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779427AA22BABE5900559A03 /* OperationFactory.swift */; };
 		7794E97B224C2518000D9F1E /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E97A224C2518000D9F1E /* Header.swift */; };
 		77B1EADE222496B500EA4FCE /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */; };
 		77B1EAED2227342200EA4FCE /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
@@ -209,6 +210,7 @@
 		7791E60F21FE862600957650 /* TezosKitExample.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = TezosKitExample.playground; path = Examples/TezosKitExample.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		779427A622BABB2700559A03 /* DefaultFeeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeeProvider.swift; sourceTree = "<group>"; };
 		779427A822BABB8E00559A03 /* TezosProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosProtocol.swift; sourceTree = "<group>"; };
+		779427AA22BABE5900559A03 /* OperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationFactory.swift; sourceTree = "<group>"; };
 		7794E97A224C2518000D9F1E /* Header.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeClient+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAE9222730D600EA4FCE /* TezosNodeIntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeIntegrationTests+Promises.swift"; sourceTree = "<group>"; };
@@ -521,6 +523,7 @@
 				77CE380F21FC7ED7006ADABA /* Operation.swift */,
 				77B1EB05222A102500EA4FCE /* OperationWithCounter.swift */,
 				779427A622BABB2700559A03 /* DefaultFeeProvider.swift */,
+				779427AA22BABE5900559A03 /* OperationFactory.swift */,
 			);
 			path = Operation;
 			sourceTree = "<group>";
@@ -918,6 +921,7 @@
 				77CE386721FC7ED8006ADABA /* TezResponseAdapter.swift in Sources */,
 				77CE385C21FC7ED8006ADABA /* OperationFees.swift in Sources */,
 				77B1EAF1222745F600EA4FCE /* RunOperationRPC.swift in Sources */,
+				779427AB22BABE5900559A03 /* OperationFactory.swift in Sources */,
 				77CE385821FC7ED8006ADABA /* MnemonicUtil.swift in Sources */,
 				77CE384A21FC7ED8006ADABA /* RevealOperation.swift in Sources */,
 				77B1EAF52228839000EA4FCE /* OperationPayload.swift in Sources */,

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		7774780C222228590010BA4D /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
 		7774780F222228E50010BA4D /* PromiseKit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7774780E222228E50010BA4D /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7776493B227616B200451DD5 /* FakeObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7776493A227616B200451DD5 /* FakeObjects.swift */; };
+		779427A722BABB2700559A03 /* DefaultFeeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779427A622BABB2700559A03 /* DefaultFeeProvider.swift */; };
+		779427A922BABB8E00559A03 /* TezosProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779427A822BABB8E00559A03 /* TezosProtocol.swift */; };
 		7794E97B224C2518000D9F1E /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7794E97A224C2518000D9F1E /* Header.swift */; };
 		77B1EADE222496B500EA4FCE /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */; };
 		77B1EAED2227342200EA4FCE /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
@@ -205,6 +207,8 @@
 		7774780E222228E50010BA4D /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromiseKit.framework; path = Carthage/Build/iOS/PromiseKit.framework; sourceTree = "<group>"; };
 		7776493A227616B200451DD5 /* FakeObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeObjects.swift; sourceTree = "<group>"; };
 		7791E60F21FE862600957650 /* TezosKitExample.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = TezosKitExample.playground; path = Examples/TezosKitExample.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		779427A622BABB2700559A03 /* DefaultFeeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeeProvider.swift; sourceTree = "<group>"; };
+		779427A822BABB8E00559A03 /* TezosProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosProtocol.swift; sourceTree = "<group>"; };
 		7794E97A224C2518000D9F1E /* Header.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeClient+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAE9222730D600EA4FCE /* TezosNodeIntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeIntegrationTests+Promises.swift"; sourceTree = "<group>"; };
@@ -516,6 +520,7 @@
 				77CE380E21FC7ED7006ADABA /* OperationKind.swift */,
 				77CE380F21FC7ED7006ADABA /* Operation.swift */,
 				77B1EB05222A102500EA4FCE /* OperationWithCounter.swift */,
+				779427A622BABB2700559A03 /* DefaultFeeProvider.swift */,
 			);
 			path = Operation;
 			sourceTree = "<group>";
@@ -533,6 +538,7 @@
 			isa = PBXGroup;
 			children = (
 				77CE381F21FC7ED7006ADABA /* Tez.swift */,
+				779427A822BABB8E00559A03 /* TezosProtocol.swift */,
 				77B1EAF222275A4A00EA4FCE /* GasLimitPolicy.swift */,
 				77CE382021FC7ED7006ADABA /* Keys.swift */,
 				77CE382121FC7ED7006ADABA /* OperationMetadata.swift */,
@@ -919,6 +925,7 @@
 				77CE387021FC7ED8006ADABA /* GetChainHeadRPC.swift in Sources */,
 				77CE387B21FC7ED8006ADABA /* GetExpectedQuorumRPC.swift in Sources */,
 				77B69EB7224E3F3A00DB4319 /* ConseilQuery.swift in Sources */,
+				779427A922BABB8E00559A03 /* TezosProtocol.swift in Sources */,
 				77CE386F21FC7ED8006ADABA /* JSONArrayResponseAdapter.swift in Sources */,
 				77CE384E21FC7ED8006ADABA /* OperationKind.swift in Sources */,
 				77B69EBB224E5F0E00DB4319 /* GetReceivedTransactions.RPC.swift in Sources */,
@@ -961,6 +968,7 @@
 				77CE387D21FC7ED8006ADABA /* TezosKitError.swift in Sources */,
 				77B69EAD224C424800DB4319 /* Transaction.swift in Sources */,
 				77CE384821FC7ED8006ADABA /* DelegationOperation.swift in Sources */,
+				779427A722BABB2700559A03 /* DefaultFeeProvider.swift in Sources */,
 				77B69EAF224C435B00DB4319 /* TransactionsResponseAdapter.swift in Sources */,
 				77CE387621FC7ED8006ADABA /* GetCurrentPeriodKindRPC.swift in Sources */,
 				77CE387921FC7ED8006ADABA /* ForgeOperationRPC.swift in Sources */,

--- a/TezosKit/Models/TezosProtocol.swift
+++ b/TezosKit/Models/TezosProtocol.swift
@@ -1,0 +1,8 @@
+// Copyright Keefer Taylor, 2019.
+
+import Foundation
+
+/// An enum listing available protocol versions supported by TezosKit.
+public enum TezosProtocol {
+  case athens // Protocol version 4
+}

--- a/TezosKit/Operation/AbstractOperation.swift
+++ b/TezosKit/Operation/AbstractOperation.swift
@@ -13,7 +13,7 @@ public class AbstractOperation: Operation {
     switch kind {
     case .delegation, .transaction, .origination:
       return true
-    case .activateAccount, .reveal:
+    case .reveal:
       return false
     }
   }

--- a/TezosKit/Operation/AbstractOperation.swift
+++ b/TezosKit/Operation/AbstractOperation.swift
@@ -7,7 +7,7 @@ import Foundation
 public class AbstractOperation: Operation {
   public let source: String
   public let kind: OperationKind
-  public let operationFees: OperationFees?
+  public let operationFees: OperationFees
 
   public var requiresReveal: Bool {
     switch kind {
@@ -23,7 +23,7 @@ public class AbstractOperation: Operation {
     operation["kind"] = kind.rawValue
     operation["source"] = source
 
-    let operationFee = self.operationFees ?? self.defaultFees
+    let operationFee = self.operationFees
     operation["storage_limit"] = operationFee.storageLimit.rpcRepresentation
     operation["gas_limit"] = operationFee.gasLimit.rpcRepresentation
     operation["fee"] = operationFee.fee.rpcRepresentation
@@ -31,15 +31,7 @@ public class AbstractOperation: Operation {
     return operation
   }
 
-  public var defaultFees: OperationFees {
-    return OperationFees(
-      fee: Tez.zeroBalance,
-      gasLimit: Tez.zeroBalance,
-      storageLimit: Tez.zeroBalance
-    )
-  }
-
-  public init(source: String, kind: OperationKind, operationFees: OperationFees? = nil) {
+  public init(source: String, kind: OperationKind, operationFees: OperationFees) {
     self.source = source
     self.kind = kind
     self.operationFees = operationFees

--- a/TezosKit/Operation/DefaultFeeProvider.swift
+++ b/TezosKit/Operation/DefaultFeeProvider.swift
@@ -1,0 +1,47 @@
+// Copyright Keefer Taylor, 2019.
+
+import Foundation
+
+/// Provides default fees for operations.
+public class DefaultFeeProvider {
+  /// Provide default fees for the given protocol.
+  ///
+  /// - Parameters:
+  ///   - operationKind: The type of operation to request default fees for.
+  ///   - tezosProtocol: The protocol to request default fees for. Default is Athens / Proto4.
+  public static func fees(
+    for operationKind: OperationKind,
+    in tezosProtocol: TezosProtocol = .athens
+  ) -> OperationFees {
+    switch tezosProtocol {
+    case .athens:
+      return feesInAthens(for: operationKind)
+    }
+  }
+
+  /// Returns default fees for the athens protocol.
+  private static func feesInAthens(for operationKind: OperationKind) -> OperationFees {
+    switch operationKind {
+    case .delegation:
+      let fee = Tez(0.001_257)
+      let storageLimit = Tez.zeroBalance
+      let gasLimit = Tez(0.010_000)
+      return OperationFees(fee: fee, gasLimit: gasLimit, storageLimit: storageLimit)
+    case .origination:
+      let fee = Tez(0.001_265)
+      let storageLimit = Tez(0.000_257)
+      let gasLimit = Tez(0.010_000)
+      return OperationFees(fee: fee, gasLimit: gasLimit, storageLimit: storageLimit)
+    case .reveal:
+      let fee = Tez(0.001_268)
+      let storageLimit = Tez.zeroBalance
+      let gasLimit = Tez(0.010_000)
+      return OperationFees(fee: fee, gasLimit: gasLimit, storageLimit: storageLimit)
+    case .transaction:
+      let fee = Tez(0.001_284)
+      let storageLimit = Tez(0.000_257)
+      let gasLimit = Tez(0.010_200)
+      return OperationFees(fee: fee, gasLimit: gasLimit, storageLimit: storageLimit)
+    }
+  }
+}

--- a/TezosKit/Operation/DelegationOperation.swift
+++ b/TezosKit/Operation/DelegationOperation.swift
@@ -17,13 +17,6 @@ public class DelegationOperation: AbstractOperation {
     return operation
   }
 
-  public override var defaultFees: OperationFees {
-    let fee = Tez(0.001_257)
-    let storageLimit = Tez.zeroBalance
-    let gasLimit = Tez(0.010_000)
-    return OperationFees(fee: fee, gasLimit: gasLimit, storageLimit: storageLimit)
-  }
-
   /// Create a delegation operation.
   ///
   /// If delegate and source are the same, then the source will be registered as a delegate.
@@ -33,8 +26,8 @@ public class DelegationOperation: AbstractOperation {
   /// - Parameters:
   ///   - source: The address that will delegate funds.
   ///   - delegate: The address to delegate to.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  internal init(source: String, delegate: String?, operationFees: OperationFees?  = nil) {
+  ///   - operationFees: OperationFees for the transaction.
+  internal init(source: String, delegate: String?, operationFees: OperationFees) {
     self.delegate = delegate
     super.init(source: source, kind: .delegation, operationFees: operationFees)
   }
@@ -42,10 +35,10 @@ public class DelegationOperation: AbstractOperation {
   /// Register the given address as a delegate.
   /// - Parameters:
   ///   - source: The address that will register as a delegate.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - operationFees: OperationFees for the transaction.
   public static func registerDelegateOperation(
     source: String,
-    operationFees: OperationFees?  = nil
+    operationFees: OperationFees
   ) -> DelegationOperation {
     return  DelegationOperation(source: source, delegate: source, operationFees: operationFees)
   }
@@ -54,11 +47,11 @@ public class DelegationOperation: AbstractOperation {
   /// - Parameters:
   ///   - source: The address that will delegate funds.
   ///   - delegate: The address to delegate to.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - operationFees: OperationFees for the transaction.
   public static func delegateOperation(
     source: String,
     to delegate: String,
-    operationFees: OperationFees? = nil
+    operationFees: OperationFees
   ) -> DelegationOperation {
     return  DelegationOperation(source: source, delegate: delegate, operationFees: operationFees)
   }
@@ -66,8 +59,8 @@ public class DelegationOperation: AbstractOperation {
   /// Clear the delegate from the given address.
   /// - Parameters:
   ///   - source: The address that will have its delegate cleared.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  public static func undelegateOperation(source: String, operationFees: OperationFees? = nil) -> DelegationOperation {
+  ///   - operationFees: OperationFees for the transaction.
+  public static func undelegateOperation(source: String, operationFees: OperationFees) -> DelegationOperation {
     return DelegationOperation(source: source, delegate: nil, operationFees: operationFees)
   }
 }

--- a/TezosKit/Operation/Operation.swift
+++ b/TezosKit/Operation/Operation.swift
@@ -10,7 +10,4 @@ public protocol Operation {
 
   /// Retrieve a dictionary representing the operation.
   var dictionaryRepresentation: [String: Any] { get }
-
-  /// The default fees for this operation.
-  var defaultFees: OperationFees { get }
 }

--- a/TezosKit/Operation/OperationFactory.swift
+++ b/TezosKit/Operation/OperationFactory.swift
@@ -1,0 +1,113 @@
+// Copyright Keefer Taylor, 2019.
+
+import Foundation
+
+/// A factory which can produce operations.
+public class OperationFactory {
+  /// The provider for default fees.
+  private let defaultFeeProvider: DefaultFeeProvider.Type
+
+  /// The protocol this operation factory will produce operations for.
+  private let tezosProtocol: TezosProtocol
+
+  /// Create a new operation factory.
+  ///
+  /// - Parameter tezosProtocol: The protocol that this factory will provide operations for. Default is athens.
+  public init(tezosProtocol: TezosProtocol = .athens) {
+    defaultFeeProvider = DefaultFeeProvider.self
+    self.tezosProtocol = tezosProtocol
+  }
+
+  /// Create a new reveal operation.
+  ///
+  /// - Parameters:
+  ///   - address: The address to reveal.
+  ///   - publicKey: The public key of the address to reveal.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  public func revealOperation(
+    from address: String,
+    publicKey: PublicKey,
+    operationFees: OperationFees? = nil
+  ) -> Operation {
+    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .reveal, in: tezosProtocol)
+    return RevealOperation(from: address, publicKey: publicKey, operationFees: operationFees)
+  }
+
+  /// Create a new origination operation.
+  ///
+  /// - Parameters:
+  ///   - address: The address which will originate the new account.
+  ///   - contractCode: Optional code to associate with the originated contract.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  public func originateOperation(
+    address: String,
+    contractCode: ContractCode? = nil,
+    operationFees: OperationFees? = nil
+  ) -> Operation {
+    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .reveal, in: tezosProtocol)
+    return OriginateAccountOperation(address: address, contractCode: contractCode, operationFees: operationFees)
+  }
+
+  /// Create a delegation operation which will register the given address as a delegate.
+  ///
+  /// - Parameters:
+  ///   - source: The address that will register as a delegate.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  public func registerDelegateOperation(
+    source: String,
+    operationFees: OperationFees?  = nil
+  ) -> Operation {
+    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .delegation, in: tezosProtocol)
+    return DelegationOperation(source: source, delegate: source, operationFees: operationFees)
+  }
+
+  /// Create a delegation operation which will delegate to the given address.
+  ///
+  /// - Parameters:
+  ///   - source: The address that will delegate funds.
+  ///   - delegate: The address to delegate to.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  public func delegateOperation(
+    source: String,
+    to delegate: String,
+    operationFees: OperationFees? = nil
+  ) -> Operation {
+    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .delegation, in: tezosProtocol)
+    return DelegationOperation(source: source, delegate: delegate, operationFees: operationFees)
+  }
+
+  /// Create a delegation operation which will clear the delegate from the given address.
+  ///
+  /// - Parameters:
+  ///   - source: The address that will have its delegate cleared.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  public func undelegateOperation(source: String, operationFees: OperationFees? = nil) -> Operation {
+    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .delegation, in: tezosProtocol)
+    return DelegationOperation(source: source, delegate: nil, operationFees: operationFees)
+  }
+
+  /// Create a new transaction operation.
+  ///
+  /// - Parameters:
+  ///   - amount: The amount of XTZ to transact.
+  ///   - from: The address that is sending the XTZ.
+  ///   - to: The address that is receiving the XTZ.
+  ///   - parameters: Optional parameters to include in the transaction if the call is being made to a smart contract.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  public func transactionOperation(
+    amount: Tez,
+    source: String,
+    destination: String,
+    parameters: [String: Any]? = nil,
+    operationFees: OperationFees? = nil
+  ) -> Operation {
+    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .transaction, in: tezosProtocol)
+    return TransactionOperation(
+      amount: amount,
+      source: source,
+      destination: destination,
+      parameters: parameters,
+      operationFees: operationFees
+    )
+  }
+}

--- a/TezosKit/Operation/OperationFactory.swift
+++ b/TezosKit/Operation/OperationFactory.swift
@@ -45,7 +45,7 @@ public class OperationFactory {
     operationFees: OperationFees? = nil
   ) -> Operation {
     let operationFees = operationFees ?? defaultFeeProvider.fees(for: .reveal, in: tezosProtocol)
-    return OriginateAccountOperation(address: address, contractCode: contractCode, operationFees: operationFees)
+    return OriginationOperation(address: address, contractCode: contractCode, operationFees: operationFees)
   }
 
   /// Create a delegation operation which will register the given address as a delegate.

--- a/TezosKit/Operation/OperationKind.swift
+++ b/TezosKit/Operation/OperationKind.swift
@@ -5,12 +5,8 @@ import Foundation
 /// An enum representing all supported operation types. Raw values of the enum represent the string the Tezos blockchain
 /// expects for the "kind" attribute when forging / pre-applying / injecting operations
 public enum OperationKind: String {
-  // Implemented operations
   case transaction
   case reveal
   case delegation
   case origination
-
-  // Planned / Unimplemented
-  case activateAccount = "activate_account"
 }

--- a/TezosKit/Operation/OriginateAccountOperation.swift
+++ b/TezosKit/Operation/OriginateAccountOperation.swift
@@ -23,31 +23,13 @@ public class OriginateAccountOperation: AbstractOperation {
     return operation
   }
 
-  public override var defaultFees: OperationFees {
-    let fee = Tez(0.001_265)
-    let storageLimit = Tez(0.000_257)
-    let gasLimit = Tez(0.010_000)
-    return OperationFees(fee: fee, gasLimit: gasLimit, storageLimit: storageLimit)
-  }
-
-  /// Create a new origination operation that will occur from the given wallet's address.
-  ///
-  /// - Parameters:
-  ///   - wallet: The wallet which will originate the new account.
-  ///   - contractCode: Optional code to associate with the originated contract.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  /// TODO: Deprecate and remove.
-  public convenience init(wallet: Wallet, contractCode: ContractCode? = nil, operationFees: OperationFees? = nil) {
-    self.init(address: wallet.address, contractCode: contractCode, operationFees: operationFees)
-  }
-
   /// Create a new origination operation that will occur from the given address.
   ///
   /// - Parameters:
   ///   - wallet: The wallet which will originate the new account.
   ///   - contractCode: Optional code to associate with the originated contract.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  public init(address: String, contractCode: ContractCode? = nil, operationFees: OperationFees? = nil) {
+  ///   - operationFees: OperationFees for the transaction.
+  public init(address: String, contractCode: ContractCode? = nil, operationFees: OperationFees) {
     managerPublicKeyHash = address
     self.contractCode = contractCode
 

--- a/TezosKit/Operation/OriginateAccountOperation.swift
+++ b/TezosKit/Operation/OriginateAccountOperation.swift
@@ -3,8 +3,7 @@
 import Foundation
 
 /// An operation that originates a new KT1 account.
-/// TODO: Rebase to `OriginateOperation`
-public class OriginateAccountOperation: AbstractOperation {
+public class OriginationOperation: AbstractOperation {
   private let managerPublicKeyHash: String
   private let contractCode: ContractCode?
 

--- a/TezosKit/Operation/OriginateAccountOperation.swift
+++ b/TezosKit/Operation/OriginateAccountOperation.swift
@@ -3,6 +3,7 @@
 import Foundation
 
 /// An operation that originates a new KT1 account.
+/// TODO: Rebase to `OriginateOperation`
 public class OriginateAccountOperation: AbstractOperation {
   private let managerPublicKeyHash: String
   private let contractCode: ContractCode?
@@ -35,6 +36,7 @@ public class OriginateAccountOperation: AbstractOperation {
   ///   - wallet: The wallet which will originate the new account.
   ///   - contractCode: Optional code to associate with the originated contract.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// TODO: Deprecate and remove.
   public convenience init(wallet: Wallet, contractCode: ContractCode? = nil, operationFees: OperationFees? = nil) {
     self.init(address: wallet.address, contractCode: contractCode, operationFees: operationFees)
   }

--- a/TezosKit/Operation/RevealOperation.swift
+++ b/TezosKit/Operation/RevealOperation.swift
@@ -16,19 +16,12 @@ public class RevealOperation: AbstractOperation {
     return operation
   }
 
-  public override var defaultFees: OperationFees {
-    let fee = Tez(0.001_268)
-    let storageLimit = Tez.zeroBalance
-    let gasLimit = Tez(0.010_000)
-    return OperationFees(fee: fee, gasLimit: gasLimit, storageLimit: storageLimit)
-  }
-
   /// Initialize a new reveal operation for the given wallet.
   ///
   /// - Parameters:
   ///   - wallet: The wallet that will be revealed.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  public convenience init(from wallet: Wallet, operationFees: OperationFees? = nil) {
+  ///   - operationFees: OperationFees for the transaction.
+  public convenience init(from wallet: Wallet, operationFees: OperationFees) {
     self.init(
       from: wallet.address,
       publicKey: wallet.keys.publicKey,
@@ -41,8 +34,8 @@ public class RevealOperation: AbstractOperation {
   /// - Parameters:
   ///   - address: The address to reveal.
   ///   - publicKey: The public key of the address to reveal.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  public init(from address: String, publicKey: PublicKey, operationFees: OperationFees? = nil) {
+  ///   - operationFees: OperationFees for the transaction.
+  public init(from address: String, publicKey: PublicKey, operationFees: OperationFees) {
     self.publicKey = publicKey.base58CheckRepresentation
     super.init(source: address, kind: .reveal, operationFees: operationFees)
   }

--- a/TezosKit/Operation/TransactionOperation.swift
+++ b/TezosKit/Operation/TransactionOperation.swift
@@ -19,42 +19,18 @@ public class TransactionOperation: AbstractOperation {
     return operation
   }
 
-  public override var defaultFees: OperationFees {
-    let fee = Tez(0.001_284)
-    let storageLimit = Tez(0.000_257)
-    let gasLimit = Tez(0.010_200)
-    return OperationFees(fee: fee, gasLimit: gasLimit, storageLimit: storageLimit)
-  }
-
-  /// - Parameters:
-  ///   - amount: The amount of XTZ to transact.
-  ///   - source: The wallet that is sending the XTZ.
-  ///   - to: The address that is receiving the XTZ.
-  ///   - parameters: Optional parameters to include in the transaction if the call is being made to a smart contract.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  /// TODO: Deprecate and remove.
-  public convenience init(
-    amount: Tez,
-    source: Wallet,
-    destination: String,
-    parameters _: [String: Any]? = nil,
-    operationFees: OperationFees? = nil
-  ) {
-    self.init(amount: amount, source: source.address, destination: destination, operationFees: operationFees)
-  }
-
   /// - Parameters:
   ///   - amount: The amount of XTZ to transact.
   ///   - from: The address that is sending the XTZ.
   ///   - to: The address that is receiving the XTZ.
   ///   - parameters: Optional parameters to include in the transaction if the call is being made to a smart contract.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - operationFees: OperationFees for the transaction.
   public init(
     amount: Tez,
     source: String,
     destination: String,
     parameters: [String: Any]? = nil,
-    operationFees: OperationFees? = nil
+    operationFees: OperationFees
   ) {
     self.amount = amount
     self.destination = destination

--- a/TezosKit/Operation/TransactionOperation.swift
+++ b/TezosKit/Operation/TransactionOperation.swift
@@ -32,6 +32,7 @@ public class TransactionOperation: AbstractOperation {
   ///   - to: The address that is receiving the XTZ.
   ///   - parameters: Optional parameters to include in the transaction if the call is being made to a smart contract.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// TODO: Deprecate and remove.
   public convenience init(
     amount: Tez,
     source: Wallet,


### PR DESCRIPTION
`OperationFactory` provides an abstraction between `TezosNodeClient` and `Operation` objects.

The factory uses `DefaultFeeProvider` to inject fees into operations. Fees are now non-optional at operation instantiation time (i.e. Defaults must be provided up front).  In the future, `OperationFactory` will provide and encapsulate more advanced fee configuration behavior.

This PR also removes some convenience initializers for simplicity. 
