### PR TITLE
Refactor ForgingService to use a NetworkClient

### DIFF
--- a/IntegrationTests/Extensions/PromiseKit/TezosNodeIntegrationTests+Promises.swift
+++ b/IntegrationTests/Extensions/PromiseKit/TezosNodeIntegrationTests+Promises.swift
@@ -154,7 +154,7 @@ extension TezosNodeIntegrationTests {
   public func testRunOperation_promises() {
     let expectation = XCTestExpectation(description: "completion called")
 
-    let operation = OperationFactory.testOperationFactory.originateOperation(address: Wallet.testWallet.address)
+    let operation = OperationFactory.testOperationFactory.originationOperation(address: Wallet.testWallet.address)
     nodeClient.runOperation(operation, from: .testWallet) .done { result in
       guard let contents = result["contents"] as? [[String: Any]],
             let metadata = contents[0]["metadata"] as? [String: Any],

--- a/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
+++ b/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
@@ -262,7 +262,7 @@ class TezosNodeIntegrationTests: XCTestCase {
   public func testRunOperation() {
     let expectation = XCTestExpectation(description: "completion called")
 
-    let operation = OperationFactory.testOperationFactory.originateOperation(address: Wallet.testWallet.address)
+    let operation = OperationFactory.testOperationFactory.originationOperation(address: Wallet.testWallet.address)
     self.nodeClient.runOperation(operation, from: .testWallet) { result in
       switch result {
       case .failure:

--- a/Tests/FakeObjects.swift
+++ b/Tests/FakeObjects.swift
@@ -7,24 +7,6 @@ public struct FakePublicKey: TezosKit.PublicKey {
   public let base58CheckRepresentation: String
 }
 
-/// A fake forging service delegate which will use the given completion call as the completion call to any remote forge
-/// request.
-public class FakeForgingServiceDelegate: ForgingServiceDelegate {
-  let completion: () -> Result<String, TezosKitError>
-  public init(completion: @escaping () -> Result<String, TezosKitError>) {
-    self.completion = completion
-  }
-
-  public func forgingService(
-    _ forgingService: ForgingService,
-    requestedRemoteForgeForPayload operationPayload: OperationPayload,
-    withMetadata operationMetadata: OperationMetadata,
-    completion: @escaping (Result<String, TezosKitError>) -> Void
-  ) {
-    completion(self.completion())
-  }
-}
-
 /// A fake signer.
 public class FakeSigner: Signer {
   private let signature: [UInt8]

--- a/Tests/TestObjects.swift
+++ b/Tests/TestObjects.swift
@@ -111,3 +111,12 @@ extension Wallet {
   public static let testWallet =
     Wallet(mnemonic: "predict corn duty process brisk tomato shrimp virtual horror half rhythm cook")!
 }
+
+extension FakeNetworkClient {
+  private static let tezosNodeClientEndpointToResponseMap = [
+    "/chains/abc/blocks/xyz/helpers/forge/operations": JSONUtils.jsonString(for: .testForgeResult)!
+  ]
+
+  public static let tezosNodeNetworkClient =
+    FakeNetworkClient(endpointToResponseMap: tezosNodeClientEndpointToResponseMap)
+}

--- a/Tests/TezosKit/ForgingServiceTests.swift
+++ b/Tests/TezosKit/ForgingServiceTests.swift
@@ -5,15 +5,9 @@ import XCTest
 
 class ForgingServiceTests: XCTestCase {
   func testForgingServiceWithRemotePolicy() {
-    let forgingServiceDelegate = FakeForgingServiceDelegate() {
-      return .success(.testForgeResult)
-    }
-
-    let forgingService = ForgingService(forgingPolicy: .remote)
-    forgingService.delegate = forgingServiceDelegate
+    let forgingService = ForgingService(forgingPolicy: .remote, networkClient: FakeNetworkClient.tezosNodeNetworkClient)
 
     let forgeCompletionExpectation = XCTestExpectation(description: "Forge completion called.")
-
     forgingService.forge(operationPayload: .testOperationPayload, operationMetadata: .testOperationMetadata) { result in
       switch result {
       case .success(let forgingServiceForgeResult):
@@ -28,7 +22,7 @@ class ForgingServiceTests: XCTestCase {
   }
 
   func testForgingServiceWithLocalPolicy() {
-    let forgingService = ForgingService(forgingPolicy: .local)
+    let forgingService = ForgingService(forgingPolicy: .local, networkClient: FakeNetworkClient.tezosNodeNetworkClient)
 
     let forgeCompletionExpectation = XCTestExpectation(description: "Forge completion called.")
     forgingService.forge(operationPayload: .testOperationPayload, operationMetadata: .testOperationMetadata) { result in
@@ -45,12 +39,10 @@ class ForgingServiceTests: XCTestCase {
   }
 
   func testForgingServiceWithLocalWithRemoteFallbackPolicyAndUnforgeableOperation() {
-    let forgingServiceDelegate = FakeForgingServiceDelegate() {
-      return .success(.testForgeResult)
-    }
-
-    let forgingService = ForgingService(forgingPolicy: .localWithRemoteFallBack)
-    forgingService.delegate = forgingServiceDelegate
+    let forgingService = ForgingService(
+      forgingPolicy: .localWithRemoteFallBack,
+      networkClient: FakeNetworkClient.tezosNodeNetworkClient
+    )
 
     let forgeCompletionExpectation = XCTestExpectation(description: "Forge completion called.")
 

--- a/TezosKit/Client/TezosNodeClient.swift
+++ b/TezosKit/Client/TezosNodeClient.swift
@@ -96,6 +96,7 @@ public class TezosNodeClient {
   public let networkClient: NetworkClient
 
   /// Initialize a new TezosNodeClient.
+  ///
   /// - Parameters:
   ///   - remoteNodeURL: The path to the remote node, defaults to the default URL
   ///   - tezosProtocol: The protocol version to use, defaults to athens.
@@ -110,7 +111,6 @@ public class TezosNodeClient {
     callbackQueue: DispatchQueue = DispatchQueue.main
   ) {
     operationFactory = OperationFactory(tezosProtocol: tezosProtocol)
-    forgingService = ForgingService(forgingPolicy: forgingPolicy)
     networkClient = NetworkClientImpl(
       remoteNodeURL: remoteNodeURL,
       urlSession: urlSession,

--- a/TezosKit/Operation/ForgingService.swift
+++ b/TezosKit/Operation/ForgingService.swift
@@ -10,7 +10,7 @@ public class ForgingService {
   /// A network client that can send requests.
   private let networkClient: NetworkClient
 
-  /// - Parameter
+  /// - Parameters:
   ///   - forgingPolicy: The forging policy to apply to all operations.
   ///   - networkClient: A network client that can communicate with a Tezos Node.
   public init(forgingPolicy: ForgingPolicy, networkClient: NetworkClient) {

--- a/TezosKit/Operation/ForgingService.swift
+++ b/TezosKit/Operation/ForgingService.swift
@@ -2,33 +2,20 @@
 
 import Foundation
 
-/// A delegate of the ForgingService.
-public protocol ForgingServiceDelegate: class {
-  /// Request that the delegate perform a remote forge of the given operation.
-  ///
-  /// - Parameters:
-  ///   - forgingService: The forging service making the request.
-  ///   - operationPayload: The operation payload to forge.
-  ///   - operationMetadata: Metadata to forge with the operation.
-  ///   - completion: A completion block to call with the result of the remote forge.
-  func forgingService(
-    _ forgingService: ForgingService,
-    requestedRemoteForgeForPayload operationPayload: OperationPayload,
-    withMetadata operationMetadata: OperationMetadata,
-    completion: @escaping (Result<String, TezosKitError>) -> Void
-  )
-}
-
 /// A service which manages forging of operations, in accordance with a ForgingPolicy.
 public class ForgingService {
   /// The forging policy to apply to all operations.
   private let forgingPolicy: ForgingPolicy
 
-  public weak var delegate: ForgingServiceDelegate?
+  /// A network client that can send requests.
+  private let networkClient: NetworkClient
 
-  /// - Parameter forgingPolicy: The forging policy to apply to all operations.
-  public init(forgingPolicy: ForgingPolicy) {
+  /// - Parameter
+  ///   - forgingPolicy: The forging policy to apply to all operations.
+  ///   - networkClient: A network client that can communicate with a Tezos Node.
+  public init(forgingPolicy: ForgingPolicy, networkClient: NetworkClient) {
     self.forgingPolicy = forgingPolicy
+    self.networkClient = networkClient
   }
 
   /// Forge the given operation by applying the forging policy encapsulated by this service.
@@ -84,23 +71,7 @@ public class ForgingService {
     operationMetadata: OperationMetadata,
     completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
-    guard let delegate = self.delegate else {
-      let noDelegateFailure: Result<String, TezosKitError> = .failure(
-        TezosKitError(
-          kind: .internalError,
-          underlyingError: "Forging service was not able to find a delegate to perform a remote forge. Check that " +
-          "ForgingService has an allocated delegate."
-        )
-      )
-      completion(noDelegateFailure)
-      return
-    }
-
-    delegate.forgingService(
-      self,
-      requestedRemoteForgeForPayload: operationPayload,
-      withMetadata: operationMetadata,
-      completion: completion
-    )
+    let rpc = ForgeOperationRPC(operationPayload: operationPayload, operationMetadata: operationMetadata)
+    networkClient.send(rpc, completion: completion)
   }
 }


### PR DESCRIPTION
This removes the `forge` functionality from `TezosNodeClient`. 

The abstraction removes unnecessary functionality from `TezosNodeClient` and moves it to a smaller and testable class. 