### PR TITLE
Use dummy signature for run operation simulations

### DIFF
--- a/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
+++ b/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
@@ -58,7 +58,7 @@ class TezosNodeIntegrationTests: XCTestCase {
 
     /// Sending a bunch of requests quickly can cause race conditions in the Tezos network as counters and operations
     /// propagate. Define a throttle period in seconds to wait between each test.
-    let intertestWaitTime: UInt32 = 30
+    let intertestWaitTime: UInt32 = 0
     sleep(intertestWaitTime)
 
     nodeClient = TezosNodeClient(remoteNodeURL: .nodeURL)
@@ -273,7 +273,8 @@ class TezosNodeIntegrationTests: XCTestCase {
     let operation = OperationFactory.testOperationFactory.originationOperation(address: Wallet.testWallet.address)
     self.nodeClient.runOperation(operation, from: .testWallet) { result in
       switch result {
-      case .failure:
+      case .failure(let error):
+        print(error)
         XCTFail()
       case .success(let data):
         guard let contents = data["contents"] as? [[String: Any]],

--- a/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
+++ b/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
@@ -58,7 +58,7 @@ class TezosNodeIntegrationTests: XCTestCase {
 
     /// Sending a bunch of requests quickly can cause race conditions in the Tezos network as counters and operations
     /// propagate. Define a throttle period in seconds to wait between each test.
-    let intertestWaitTime: UInt32 = 0
+    let intertestWaitTime: UInt32 = 30
     sleep(intertestWaitTime)
 
     nodeClient = TezosNodeClient(remoteNodeURL: .nodeURL)

--- a/TezosKit/Client/TezosNodeClient.swift
+++ b/TezosKit/Client/TezosNodeClient.swift
@@ -1,5 +1,6 @@
 // Copyright Keefer Taylor, 2019
 
+import Base58Swift
 import Foundation
 import TezosCrypto
 
@@ -404,8 +405,10 @@ public class TezosNodeClient {
           return
         }
 
+        let bunkSig =
+          "edsigtXomBKi5CTRf5cjATJWSyaRvhfYNHqSUGrn4SdbYRcGwQrUGjzEfQDTuqHhuA8b2d8NarZjz8TRf65WkpQmo423BtomS8Q"
         guard
-          let signature = SigningService.sign(bytes, with: wallet),
+          let signature = Base58.base58CheckDecodeWithPrefix(string: bunkSig, prefix: Prefix.Sign.signature),
           let signedOperationPayload = SignedOperationPayload(
             operationPayload: operationPayload,
             signature: signature


### PR DESCRIPTION
This hotfix means that signed payloads are not transmitted to (potentially malicious) remote nodes.