### PR TITLE
Fee Estimation

### DIFF
--- a/Extensions/PromiseKit/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNodeClient+Promises.swift
@@ -5,6 +5,9 @@ import PromiseKit
 
 /// Extension to TezosNodeClient which provides PromiseKit functionality.
 extension TezosNodeClient {
+
+  // MARK: - Queries
+
   /// Retrieve data about the chain head.
   public func getHead() -> Promise<[String: Any]> {
     let rpc = GetChainHeadRPC()
@@ -49,162 +52,6 @@ extension TezosNodeClient {
   public func getAddressManagerKey(address: Address) -> Promise<[String: Any]> {
     let rpc = GetAddressManagerKeyRPC(address: address)
     return networkClient.send(rpc)
-  }
-
-  /// Transact Tezos between accounts.
-  /// - Parameters:
-  ///   - amount: The amount of Tez to send.
-  ///   - recipientAddress: The address which will receive the Tez.
-  ///   - source: The address sending the balance.
-  ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  /// - Returns: A promise which resolves to a string representing the transaction hash.
-  public func send(
-    amount: Tez,
-    to recipientAddress: String,
-    from source: Address,
-    signatureProvider: SignatureProvider,
-    operationFees: OperationFees? = nil
-  ) -> Promise<String> {
-    let transactionOperation = operationFactory.transactionOperation(
-      amount: amount,
-      source: source,
-      destination: recipientAddress,
-      operationFees: operationFees
-    )
-    return forgeSignPreapplyAndInject(
-      operation: transactionOperation,
-      source: source,
-      signatureProvider: signatureProvider
-    )
-  }
-
-  /// Call a smart contract.
-  ///
-  /// - Parameters:
-  ///   - contract: The smart contract to invoke.
-  ///   - amount: The amount of Tez to transfer with the invocation. Default is 0.
-  ///   - parameter: An optional parameter to send to the smart contract. Default is none.
-  ///   - source: The address invoking the contract.
-  ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  /// - Returns: A promise which resolves to a string representing the transaction hash.
-  public func call(
-    contract: Address,
-    amount: Tez = Tez.zeroBalance,
-    parameter: MichelsonParameter? = nil,
-    source: Address,
-    signatureProvider: SignatureProvider,
-    operationFees: OperationFees? = nil
-  ) -> Promise<String> {
-    let smartContractInvocationOperation = operationFactory.smartContractInvocationOperation(
-      amount: amount,
-      parameter: parameter,
-      source: source,
-      destination: contract,
-      operationFees: operationFees
-    )
-    return forgeSignPreapplyAndInject(
-      operation: smartContractInvocationOperation,
-      source: source,
-      signatureProvider: signatureProvider
-    )
-  }
-
-  /// Delegate the balance of an originated account.
-  ///
-  /// Note that only KT1 accounts can delegate. TZ1 accounts are not able to delegate. This invariant
-  /// is not checked on an input to this methods. Thus, the source address must be a KT1 address and
-  /// the keys to sign the operation for the address are the keys used to manage the TZ1 address.
-  ///
-  /// - Parameters:
-  ///   - source: The address which will delegate.
-  ///   - delegate: The address which will receive the delegation.
-  ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  /// - Returns: A promise which resolves to a string representing the transaction hash.
-  public func delegate(
-    from source: Address,
-    to delegate: Address,
-    signatureProvider: SignatureProvider,
-    operationFees: OperationFees? = nil
-  ) -> Promise<String> {
-    let delegationOperation = operationFactory.delegateOperation(
-      source: source,
-      to: delegate,
-      operationFees: operationFees
-    )
-    return forgeSignPreapplyAndInject(
-      operation: delegationOperation,
-      source: source,
-      signatureProvider: signatureProvider
-    )
-  }
-
-  /// Clear the delegate of an originated account.
-  /// - Parameters:
-  ///   - source: The address which is removing the delegate.
-  ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  /// - Returns: A promise which resolves to a string representing the transaction hash.
-  public func undelegate(
-    from source: Address,
-    signatureProvider: SignatureProvider,
-    operationFees: OperationFees? = nil
-  ) -> Promise<String> {
-    let undelegateOperatoin = operationFactory.undelegateOperation(
-      source: source,
-      operationFees: operationFees
-    )
-    return forgeSignPreapplyAndInject(
-      operation: undelegateOperatoin,
-      source: source,
-      signatureProvider: signatureProvider
-    )
-  }
-
-  /// Register an address as a delegate.
-  /// - Parameters:
-  ///   - delegate: The address registering as a delegate.
-  ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  /// - Returns: A promise which resolves to a string representing the transaction hash.
-  public func registerDelegate(
-    delegate: Address,
-    signatureProvider: SignatureProvider,
-    operationFees: OperationFees? = nil
-  ) -> Promise<String> {
-    let registerDelegateOperation = operationFactory.registerDelegateOperation(
-      source: delegate,
-      operationFees: operationFees
-    )
-    return forgeSignPreapplyAndInject(
-      operation: registerDelegateOperation,
-      source: delegate,
-      signatureProvider: signatureProvider
-    )
-  }
-
-  /// Originate a new account from the given account.
-  /// - Parameters:
-  ///   - managerAddress: The address which will manage the new account.
-  ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  /// - Returns: A promise which resolves to a string representing the transaction hash.
-  public func originateAccount(
-    managerAddress: String,
-    signatureProvider: SignatureProvider,
-    operationFees: OperationFees? = nil
-  ) -> Promise<String> {
-    let originationOperation = operationFactory.originationOperation(
-      address: managerAddress,
-      operationFees: operationFees
-    )
-    return forgeSignPreapplyAndInject(
-      operation: originationOperation,
-      source: managerAddress,
-      signatureProvider: signatureProvider
-    )
   }
 
   /// Retrieve ballots cast so far during a voting period.
@@ -255,27 +102,9 @@ extension TezosNodeClient {
   /// - Returns: A promise that resolves with the storage of the contract.
   public func getContractStorage(
     address: Address
-  ) -> Promise<[String: Any]> {
+    ) -> Promise<[String: Any]> {
     let rpc = GetContractStorageRPC(address: address)
     return networkClient.send(rpc)
-  }
-
-  /// Forge, sign, preapply and then inject a single operation.
-  /// - Parameters:
-  ///   - operation: The operation which will be forged.
-  ///   - source: The address performing the operation.
-  ///   - signatureProvider: The object which will sign the operation.
-  /// - Returns: A promise which resolves to a string representing the transaction hash.
-  public func forgeSignPreapplyAndInject(
-    operation: Operation,
-    source: Address,
-    signatureProvider: SignatureProvider
-  ) -> Promise<String> {
-    return forgeSignPreapplyAndInject(
-      operations: [operation],
-      source: source,
-      signatureProvider: signatureProvider
-    )
   }
 
   /// Inspect the value of a big map in a smart contract.
@@ -288,9 +117,350 @@ extension TezosNodeClient {
     address: Address,
     key: MichelsonParameter,
     type: MichelsonComparable
-  ) -> Promise<[String: Any]> {
+    ) -> Promise<[String: Any]> {
     let rpc = GetBigMapValueRPC(address: address, key: key, type: type)
     return networkClient.send(rpc)
+  }
+
+  // MARK: - Operations
+
+  /// Transact Tezos between accounts.
+  ///
+  /// - Parameters:
+  ///   - amount: The amount of Tez to send.
+  ///   - recipientAddress: The address which will receive the Tez.
+  ///   - source: The address sending the balance.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func send(
+    amount: Tez,
+    to recipientAddress: String,
+    from source: Address,
+    signatureProvider: SignatureProvider,
+    operationFees: OperationFees? = nil
+  ) -> Promise<String> {
+    var policy = OperationFeePolicy.default
+    if let operationFees = operationFees {
+      policy = .custom(operationFees)
+    }
+
+    return send(
+      amount: amount,
+      to: recipientAddress,
+      from: source,
+      signatureProvider: signatureProvider,
+      operationFeePolicy: policy
+    )
+  }
+
+  /// Call a smart contract.
+  ///
+  /// - Parameters:
+  ///   - contract: The smart contract to invoke.
+  ///   - amount: The amount of Tez to transfer with the invocation. Default is 0.
+  ///   - parameter: An optional parameter to send to the smart contract. Default is none.
+  ///   - source: The address invoking the contract.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func call(
+    contract: Address,
+    amount: Tez = Tez.zeroBalance,
+    parameter: MichelsonParameter? = nil,
+    source: Address,
+    signatureProvider: SignatureProvider,
+    operationFees: OperationFees? = nil
+  ) -> Promise<String> {
+    var policy = OperationFeePolicy.default
+    if let operationFees = operationFees {
+      policy = .custom(operationFees)
+    }
+
+    return call(
+      contract: contract,
+      amount: amount,
+      parameter: parameter,
+      source: source,
+      signatureProvider: signatureProvider,
+      operationFeePolicy: policy
+    )
+  }
+
+  /// Delegate the balance of an originated account.
+  ///
+  /// Note that only KT1 accounts can delegate. TZ1 accounts are not able to delegate. This invariant
+  /// is not checked on an input to this methods. Thus, the source address must be a KT1 address and
+  /// the keys to sign the operation for the address are the keys used to manage the TZ1 address.
+  ///
+  /// - Parameters:
+  ///   - source: The address which will delegate.
+  ///   - delegate: The address which will receive the delegation.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func delegate(
+    from source: Address,
+    to delegate: Address,
+    signatureProvider: SignatureProvider,
+    operationFees: OperationFees? = nil
+  ) -> Promise<String> {
+    var policy = OperationFeePolicy.default
+    if let operationFees = operationFees {
+      policy = .custom(operationFees)
+    }
+
+    return self.delegate(from: source, to: delegate, signatureProvider: signatureProvider, operationFeePolicy: policy)
+  }
+
+  /// Clear the delegate of an originated account.
+  ///
+  /// - Parameters:
+  ///   - source: The address which is removing the delegate.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func undelegate(
+    from source: Address,
+    signatureProvider: SignatureProvider,
+    operationFees: OperationFees? = nil
+  ) -> Promise<String> {
+    var policy = OperationFeePolicy.default
+    if let operationFees = operationFees {
+      policy = .custom(operationFees)
+    }
+
+    return undelegate(from: source, signatureProvider: signatureProvider, operationFeePolicy: policy)
+  }
+
+  /// Register an address as a delegate.
+  ///
+  /// - Parameters:
+  ///   - delegate: The address registering as a delegate.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func registerDelegate(
+    delegate: Address,
+    signatureProvider: SignatureProvider,
+    operationFees: OperationFees? = nil
+  ) -> Promise<String> {
+    var policy = OperationFeePolicy.default
+    if let operationFees = operationFees {
+      policy = .custom(operationFees)
+    }
+
+    return registerDelegate(delegate: delegate, signatureProvider: signatureProvider, operationFeePolicy: policy)
+  }
+
+  /// Originate a new account from the given account.
+  ///
+  /// - Parameters:
+  ///   - managerAddress: The address which will manage the new account.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func originateAccount(
+    managerAddress: String,
+    signatureProvider: SignatureProvider,
+    operationFees: OperationFees? = nil
+  ) -> Promise<String> {
+    var policy = OperationFeePolicy.default
+    if let operationFees = operationFees {
+      policy = .custom(operationFees)
+    }
+
+    return originateAccount(
+      managerAddress: managerAddress,
+      signatureProvider: signatureProvider,
+      operationFeePolicy: policy
+    )
+  }
+
+  /// Transact Tezos between accounts.
+  ///
+  /// - Parameters:
+  ///   - amount: The amount of Tez to send.
+  ///   - recipientAddress: The address which will receive the Tez.
+  ///   - source: The address sending the balance.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  internal func send(
+    amount: Tez,
+    to recipientAddress: String,
+    from source: Address,
+    signatureProvider: SignatureProvider,
+    operationFeePolicy: OperationFeePolicy
+  ) -> Promise<String> {
+    let transactionOperation = operationFactory.transactionOperation(
+      amount: amount,
+      source: source,
+      destination: recipientAddress,
+      operationFeePolicy: operationFeePolicy
+    )
+    return forgeSignPreapplyAndInject(
+      operation: transactionOperation,
+      source: source,
+      signatureProvider: signatureProvider
+    )
+  }
+
+  /// Call a smart contract.
+  ///
+  /// - Parameters:
+  ///   - contract: The smart contract to invoke.
+  ///   - amount: The amount of Tez to transfer with the invocation. Default is 0.
+  ///   - parameter: An optional parameter to send to the smart contract. Default is none.
+  ///   - source: The address invoking the contract.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  internal func call(
+    contract: Address,
+    amount: Tez = Tez.zeroBalance,
+    parameter: MichelsonParameter? = nil,
+    source: Address,
+    signatureProvider: SignatureProvider,
+    operationFeePolicy: OperationFeePolicy
+  ) -> Promise<String> {
+    let smartContractInvocationOperation = operationFactory.smartContractInvocationOperation(
+      amount: amount,
+      parameter: parameter,
+      source: source,
+      destination: contract,
+      operationFeePolicy: operationFeePolicy
+    )
+    return forgeSignPreapplyAndInject(
+      operation: smartContractInvocationOperation,
+      source: source,
+      signatureProvider: signatureProvider
+    )
+  }
+
+  /// Delegate the balance of an originated account.
+  ///
+  /// Note that only KT1 accounts can delegate. TZ1 accounts are not able to delegate. This invariant
+  /// is not checked on an input to this methods. Thus, the source address must be a KT1 address and
+  /// the keys to sign the operation for the address are the keys used to manage the TZ1 address.
+  ///
+  /// - Parameters:
+  ///   - source: The address which will delegate.
+  ///   - delegate: The address which will receive the delegation.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  internal func delegate(
+    from source: Address,
+    to delegate: Address,
+    signatureProvider: SignatureProvider,
+    operationFeePolicy: OperationFeePolicy
+  ) -> Promise<String> {
+    let delegationOperation = operationFactory.delegateOperation(
+      source: source,
+      to: delegate,
+      operationFeePolicy: operationFeePolicy
+    )
+    return forgeSignPreapplyAndInject(
+      operation: delegationOperation,
+      source: source,
+      signatureProvider: signatureProvider
+    )
+  }
+
+  /// Clear the delegate of an originated account.
+  ///
+  /// - Parameters:
+  ///   - source: The address which is removing the delegate.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  internal func undelegate(
+    from source: Address,
+    signatureProvider: SignatureProvider,
+    operationFeePolicy: OperationFeePolicy
+  ) -> Promise<String> {
+    let undelegateOperatoin = operationFactory.undelegateOperation(
+      source: source,
+      operationFeePolicy: operationFeePolicy
+    )
+    return forgeSignPreapplyAndInject(
+      operation: undelegateOperatoin,
+      source: source,
+      signatureProvider: signatureProvider
+    )
+  }
+
+  /// Register an address as a delegate.
+  ///
+  /// - Parameters:
+  ///   - delegate: The address registering as a delegate.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  internal func registerDelegate(
+    delegate: Address,
+    signatureProvider: SignatureProvider,
+    operationFeePolicy: OperationFeePolicy
+  ) -> Promise<String> {
+    let registerDelegateOperation = operationFactory.registerDelegateOperation(
+      source: delegate,
+      operationFeePolicy: operationFeePolicy
+    )
+    return forgeSignPreapplyAndInject(
+      operation: registerDelegateOperation,
+      source: delegate,
+      signatureProvider: signatureProvider
+    )
+  }
+
+  /// Originate a new account from the given account.
+  ///
+  /// - Parameters:
+  ///   - managerAddress: The address which will manage the new account.
+  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  internal func originateAccount(
+    managerAddress: String,
+    signatureProvider: SignatureProvider,
+    operationFeePolicy: OperationFeePolicy
+  ) -> Promise<String> {
+    let originationOperation = operationFactory.originationOperation(
+      address: managerAddress,
+      operationFeePolicy: operationFeePolicy
+    )
+    return forgeSignPreapplyAndInject(
+      operation: originationOperation,
+      source: managerAddress,
+      signatureProvider: signatureProvider
+    )
+  }
+
+  /// Forge, sign, preapply and then inject a single operation.
+  ///
+  /// Operations are processed in the order they are placed in the operation array.
+  ///
+  /// - Parameters:
+  ///   - operation: An operation that will be forged.
+  ///   - source: The address performing the operation.
+  ///   - signatureProvider: The object which will sign the operation.
+  /// - Returns: A promise which resolves to a string representing the transaction hash.
+  public func forgeSignPreapplyAndInject(
+    operation: Operation,
+    source: Address,
+    signatureProvider: SignatureProvider
+    ) -> Promise<String> {
+    return Promise { seal in
+      forgeSignPreapplyAndInject([operation], source: source, signatureProvider: signatureProvider) { result in
+        switch result {
+        case .success(let data):
+          seal.fulfill(data)
+        case .failure(let error):
+          seal.reject(error)
+        }
+      }
+    }
   }
 
   /// Forge, sign, preapply and then inject a single operation.

--- a/IntegrationTests/Extensions/PromiseKit/TezosNodeIntegrationTests+Promises.swift
+++ b/IntegrationTests/Extensions/PromiseKit/TezosNodeIntegrationTests+Promises.swift
@@ -156,7 +156,7 @@ extension TezosNodeIntegrationTests {
 
     let operation = OperationFactory.testOperationFactory.originationOperation(
       address: Wallet.testWallet.address,
-      operationFees: nil
+      operationFeePolicy: .default
     )
     self.nodeClient.runOperation(operation, from: .testWallet).done { simulationResult in
       guard case .success(let consumedGas, let consumedStorage) = simulationResult else {
@@ -205,13 +205,13 @@ extension TezosNodeIntegrationTests {
         amount: Tez("1")!,
         source: Wallet.testWallet.address,
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5",
-        operationFees: nil
+        operationFeePolicy: .default
       ),
       OperationFactory.testOperationFactory.transactionOperation(
         amount: Tez("2")!,
         source: Wallet.testWallet.address,
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5",
-        operationFees: nil
+        operationFeePolicy: .default
       )
     ]
 

--- a/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
+++ b/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
@@ -289,7 +289,7 @@ class TezosNodeIntegrationTests: XCTestCase {
 
     let operation = OperationFactory.testOperationFactory.originationOperation(
       address: Wallet.testWallet.address,
-      operationFees: nil
+      operationFeePolicy: .default
     )
     self.nodeClient.runOperation(operation, from: .testWallet) { result in
       switch result {
@@ -318,13 +318,13 @@ class TezosNodeIntegrationTests: XCTestCase {
         amount: Tez("1")!,
         source: Wallet.testWallet.address,
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5",
-        operationFees: nil
+        operationFeePolicy: .default
       ),
       OperationFactory.testOperationFactory.transactionOperation(
         amount: Tez("2")!,
         source: Wallet.testWallet.address,
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5",
-        operationFees: nil
+        operationFeePolicy: .default
       )
     ]
 

--- a/Tests/TezosKit/DelegationOperationTest.swift
+++ b/Tests/TezosKit/DelegationOperationTest.swift
@@ -8,7 +8,11 @@ class DelegationOperationTest: XCTestCase {
     let source = "tz1abc"
     let delegate = "tz1def"
 
-    let operation = OperationFactory.testFactory.delegateOperation(source: source, to: delegate, operationFees: nil)
+    let operation = OperationFactory.testFactory.delegateOperation(
+      source: source,
+      to: delegate,
+      operationFeePolicy: .default
+    )
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])
@@ -21,7 +25,7 @@ class DelegationOperationTest: XCTestCase {
   public func testDictionaryRepresentation_undelegate() {
     let source = "tz1abc"
 
-    let operation = OperationFactory.testFactory.undelegateOperation(source: source, operationFees: nil)
+    let operation = OperationFactory.testFactory.undelegateOperation(source: source, operationFeePolicy: .default)
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])
@@ -33,7 +37,7 @@ class DelegationOperationTest: XCTestCase {
   public func testDictionaryRepresentation_registerDelegate() {
     let source = "tz1abc"
 
-    let operation = OperationFactory.testFactory.registerDelegateOperation(source: source, operationFees: nil)
+    let operation = OperationFactory.testFactory.registerDelegateOperation(source: source, operationFeePolicy: .default)
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])

--- a/Tests/TezosKit/OperationFactoryTest.swift
+++ b/Tests/TezosKit/OperationFactoryTest.swift
@@ -12,7 +12,7 @@ class OperationFactoryTest: XCTestCase {
     let revealOperation = operationFactory.revealOperation(
       from: "tz1abc",
       publicKey: FakePublicKey(base58CheckRepresentation: "xyz"),
-      operationFees: nil
+      operationFeePolicy: .default
     )
 
     let defaultFees = DefaultFeeProvider.fees(for: .reveal)
@@ -24,7 +24,7 @@ class OperationFactoryTest: XCTestCase {
   func testOriginationOperationWithDefaultFees() {
     let originationOperation = operationFactory.originationOperation(
       address: "tz1abc",
-      operationFees: nil
+      operationFeePolicy: .default
     )
 
     let defaultFees = DefaultFeeProvider.fees(for: .origination)
@@ -38,7 +38,7 @@ class OperationFactoryTest: XCTestCase {
       amount: Tez(1.0),
       source: "tz1abc",
       destination: "tz2xyz",
-      operationFees: nil
+      operationFeePolicy: .default
     )
 
     let defaultFees = DefaultFeeProvider.fees(for: .transaction)
@@ -48,7 +48,11 @@ class OperationFactoryTest: XCTestCase {
   }
 
   func testDelegationOperationWithDefaultFees() {
-    let delegationOperation = operationFactory.delegateOperation(source: "tz1abc", to: "tz2xyz", operationFees: nil)
+    let delegationOperation = operationFactory.delegateOperation(
+      source: "tz1abc",
+      to: "tz2xyz",
+      operationFeePolicy: .default
+    )
 
     let defaultFees = DefaultFeeProvider.fees(for: .delegation)
     XCTAssertEqual(delegationOperation.operationFees.fee, defaultFees.fee)
@@ -57,7 +61,10 @@ class OperationFactoryTest: XCTestCase {
   }
 
   func testRegisterDelegateOperationWithDefaultFees() {
-    let registerDelegateOperation = operationFactory.registerDelegateOperation(source: "tz1abc", operationFees: nil)
+    let registerDelegateOperation = operationFactory.registerDelegateOperation(
+      source: "tz1abc",
+      operationFeePolicy: .default
+    )
 
     let defaultFees = DefaultFeeProvider.fees(for: .delegation)
     XCTAssertEqual(registerDelegateOperation.operationFees.fee, defaultFees.fee)
@@ -66,7 +73,7 @@ class OperationFactoryTest: XCTestCase {
   }
 
   func testUndelegateOperationWithDefaultFees() {
-    let clearDelegateOperation = operationFactory.undelegateOperation(source: "tz1abc", operationFees: nil)
+    let clearDelegateOperation = operationFactory.undelegateOperation(source: "tz1abc", operationFeePolicy: .default)
 
     let defaultFees = DefaultFeeProvider.fees(for: .delegation)
     XCTAssertEqual(clearDelegateOperation.operationFees.fee, defaultFees.fee)
@@ -80,7 +87,7 @@ class OperationFactoryTest: XCTestCase {
     let revealOperation = operationFactory.revealOperation(
       from: "tz1abc",
       publicKey: FakePublicKey(base58CheckRepresentation: "xyz"),
-      operationFees: .testFees
+      operationFeePolicy: .custom(.testFees)
     )
 
     XCTAssertEqual(revealOperation.operationFees.fee, OperationFees.testFees.fee)
@@ -91,7 +98,7 @@ class OperationFactoryTest: XCTestCase {
   func testOriginationOperationWithCustomFees() {
     let originationOperation = operationFactory.originationOperation(
       address: "tz1abc",
-      operationFees: .testFees
+      operationFeePolicy: .custom(.testFees)
     )
 
     XCTAssertEqual(originationOperation.operationFees.fee, OperationFees.testFees.fee)
@@ -104,7 +111,7 @@ class OperationFactoryTest: XCTestCase {
       amount: Tez(1.0),
       source: "tz1abc",
       destination: "tz2xyz",
-      operationFees: .testFees
+      operationFeePolicy: .custom(.testFees)
     )
 
     XCTAssertEqual(transactionOperation.operationFees.fee, OperationFees.testFees.fee)
@@ -116,7 +123,7 @@ class OperationFactoryTest: XCTestCase {
     let delegationOperation = operationFactory.delegateOperation(
       source: "tz1abc",
       to: "tz2xyz",
-      operationFees: .testFees
+      operationFeePolicy: .custom(.testFees)
     )
 
     XCTAssertEqual(delegationOperation.operationFees.fee, OperationFees.testFees.fee)
@@ -127,7 +134,7 @@ class OperationFactoryTest: XCTestCase {
   func testRegisterDelegateOperationWithCustomFees() {
     let registerDelegateOperation = operationFactory.registerDelegateOperation(
       source: "tz1abc",
-      operationFees: .testFees
+      operationFeePolicy: .custom(.testFees)
     )
 
     XCTAssertEqual(registerDelegateOperation.operationFees.fee, OperationFees.testFees.fee)
@@ -136,7 +143,10 @@ class OperationFactoryTest: XCTestCase {
   }
 
   func testUndelegateOperationWithCustomFees() {
-    let clearDelegateOperation = operationFactory.undelegateOperation(source: "tz1abc", operationFees: .testFees)
+    let clearDelegateOperation = operationFactory.undelegateOperation(
+      source: "tz1abc",
+      operationFeePolicy: .custom(.testFees)
+    )
 
     XCTAssertEqual(clearDelegateOperation.operationFees.fee, OperationFees.testFees.fee)
     XCTAssertEqual(clearDelegateOperation.operationFees.gasLimit, OperationFees.testFees.gasLimit)

--- a/Tests/TezosKit/OperationPayloadTest.swift
+++ b/Tests/TezosKit/OperationPayloadTest.swift
@@ -22,7 +22,11 @@ final class OperationPayloadTest: XCTestCase {
   /// Test a single operation with a revealed manager key.
   func testOperationPayloadInitSingleOperation() {
     let operations = [
-      operationFactory.delegateOperation(source: .testAddress, to: .testDestinationAddress, operationFees: nil)
+      operationFactory.delegateOperation(
+        source: .testAddress,
+        to: .testDestinationAddress,
+        operationFeePolicy: .default
+      )
     ]
 
     let operationPayload = OperationPayload(
@@ -43,8 +47,12 @@ final class OperationPayloadTest: XCTestCase {
   /// Test multiple operations with a revealed manager key.
   func testOperationPayloadInitMultipleOperations() {
     let operations = [
-      operationFactory.delegateOperation(source: .testAddress, to: .testDestinationAddress, operationFees: nil),
-      operationFactory.registerDelegateOperation(source: .testAddress, operationFees: nil)
+      operationFactory.delegateOperation(
+        source: .testAddress,
+        to: .testDestinationAddress,
+        operationFeePolicy: .default
+      ),
+      operationFactory.registerDelegateOperation(source: .testAddress, operationFeePolicy: .default)
     ]
 
     let operationPayload = OperationPayload(
@@ -65,8 +73,12 @@ final class OperationPayloadTest: XCTestCase {
   /// Test an operation requiring a reveal without a revealed manager key.
   func testOperationPayloadInitWithUnrevealedKeyRevealRequired() {
     let operations = [
-      operationFactory.delegateOperation(source: .testAddress, to: .testDestinationAddress, operationFees: nil),
-      operationFactory.registerDelegateOperation(source: .testAddress, operationFees: nil)
+      operationFactory.delegateOperation(
+        source: .testAddress,
+        to: .testDestinationAddress,
+        operationFeePolicy: .default
+      ),
+      operationFactory.registerDelegateOperation(source: .testAddress, operationFeePolicy: .default)
     ]
 
     let operationPayload = OperationPayload(
@@ -89,7 +101,11 @@ final class OperationPayloadTest: XCTestCase {
   /// Test an operation not requiring a reveal without a revealed manager key.
   func testOperationPayloadInitWithUnrevealedKeyRevealNotRequired() {
     let operations = [
-      operationFactory.revealOperation(from: .testAddress, publicKey: signatureProvider.publicKey, operationFees: nil)
+      operationFactory.revealOperation(
+        from: .testAddress,
+        publicKey: signatureProvider.publicKey,
+        operationFeePolicy: .default
+      )
     ]
 
     let operationPayload = OperationPayload(

--- a/Tests/TezosKit/RevealOperationTest.swift
+++ b/Tests/TezosKit/RevealOperationTest.swift
@@ -8,7 +8,11 @@ class RevealOperationTest: XCTestCase {
     let source = "tz1abc"
     let publicKey = FakePublicKey(base58CheckRepresentation: "edpkXYZ")
 
-    let operation = OperationFactory.testFactory.revealOperation(from: source, publicKey: publicKey, operationFees: nil)
+    let operation = OperationFactory.testFactory.revealOperation(
+      from: source,
+      publicKey: publicKey,
+      operationFeePolicy: .default
+    )
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])

--- a/Tests/TezosKit/SimulationServiceTest.swift
+++ b/Tests/TezosKit/SimulationServiceTest.swift
@@ -17,7 +17,7 @@ final class SimulationServiceTest: XCTestCase {
     let operation = operationFactory.delegateOperation(
       source: .testAddress,
       to: .testDestinationAddress,
-      operationFees: nil
+      operationFeePolicy: .default
     )
 
     let simulationCompletionExpectation = XCTestExpectation(description: "Simulation completion called.")
@@ -53,7 +53,7 @@ final class SimulationServiceTest: XCTestCase {
     let operation = operationFactory.delegateOperation(
       source: .testAddress,
       to: .testDestinationAddress,
-      operationFees: nil
+      operationFeePolicy: .default
     )
 
     let simulationCompletionExpectation = XCTestExpectation(description: "Simulation completion called.")

--- a/Tests/TezosKit/TransactionOperationTest.swift
+++ b/Tests/TezosKit/TransactionOperationTest.swift
@@ -14,7 +14,7 @@ class TransactionOperationTest: XCTestCase {
       amount: balance,
       source: .testAddress,
       destination: .testDestinationAddress,
-      operationFees: nil
+      operationFeePolicy: .default
     )
     let dictionary = operation.dictionaryRepresentation
 
@@ -36,7 +36,7 @@ class TransactionOperationTest: XCTestCase {
       parameter: parameter,
       source: .testAddress,
       destination: .testDestinationAddress,
-      operationFees: nil
+      operationFeePolicy: .default
     )
     let dictionary = operation.dictionaryRepresentation
 

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		779A9C5A2308634E004C6575 /* SimulationResultResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779A9C592308634E004C6575 /* SimulationResultResponseAdapterTest.swift */; };
 		779A9C5C230864EE004C6575 /* SimulationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779A9C5B230864EE004C6575 /* SimulationResult.swift */; };
 		779A9C5E23086558004C6575 /* SimulationResultResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779A9C5D23086558004C6575 /* SimulationResultResponseAdapter.swift */; };
+		779A9C60230A49EA004C6575 /* OperationFeePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779A9C5F230A49EA004C6575 /* OperationFeePolicy.swift */; };
 		77B1EADE222496B500EA4FCE /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */; };
 		77B1EAED2227342200EA4FCE /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F4D26B221F899800D34B01 /* PromiseKit.framework */; };
 		77B1EAEF222736FC00EA4FCE /* PromiseKit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 7774780E222228E50010BA4D /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -275,6 +276,7 @@
 		779A9C592308634E004C6575 /* SimulationResultResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationResultResponseAdapterTest.swift; sourceTree = "<group>"; };
 		779A9C5B230864EE004C6575 /* SimulationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationResult.swift; sourceTree = "<group>"; };
 		779A9C5D23086558004C6575 /* SimulationResultResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationResultResponseAdapter.swift; sourceTree = "<group>"; };
+		779A9C5F230A49EA004C6575 /* OperationFeePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationFeePolicy.swift; sourceTree = "<group>"; };
 		77B1EADD222496B500EA4FCE /* TezosNodeClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeClient+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAE9222730D600EA4FCE /* TezosNodeIntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeIntegrationTests+Promises.swift"; sourceTree = "<group>"; };
 		77B1EAF0222745F600EA4FCE /* RunOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunOperationRPC.swift; sourceTree = "<group>"; };
@@ -617,6 +619,7 @@
 			isa = PBXGroup;
 			children = (
 				779427B022BB24C800559A03 /* ForgingPolicy.swift */,
+				779A9C5F230A49EA004C6575 /* OperationFeePolicy.swift */,
 				779A9C5B230864EE004C6575 /* SimulationResult.swift */,
 				7719266122DCD77500E63DE4 /* InjectionService.swift */,
 				7719265D22DA1A5800E63DE4 /* SimulationService.swift */,
@@ -1036,6 +1039,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				779A9C60230A49EA004C6575 /* OperationFeePolicy.swift in Sources */,
 				77B69EA4224C38C700DB4319 /* ConseilClient.swift in Sources */,
 				77CE386B21FC7ED8006ADABA /* IntegerResponseAdapter.swift in Sources */,
 				77FE787622EC333B00B85B9D /* UnitMichelsonParameter.swift in Sources */,

--- a/TezosKit.xcodeproj/xcshareddata/xcschemes/TezosKit.xcscheme
+++ b/TezosKit.xcodeproj/xcshareddata/xcschemes/TezosKit.xcscheme
@@ -39,6 +39,16 @@
                ReferencedContainer = "container:TezosKit.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "772F48A42224894E00DF0F9D"
+               BuildableName = "IntegrationTests.xctest"
+               BlueprintName = "IntegrationTests"
+               ReferencedContainer = "container:TezosKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/TezosKit.xcodeproj/xcshareddata/xcschemes/TezosKit.xcscheme
+++ b/TezosKit.xcodeproj/xcshareddata/xcschemes/TezosKit.xcscheme
@@ -39,16 +39,6 @@
                ReferencedContainer = "container:TezosKit.xcodeproj">
             </BuildableReference>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "772F48A42224894E00DF0F9D"
-               BuildableName = "IntegrationTests.xctest"
-               BlueprintName = "IntegrationTests"
-               ReferencedContainer = "container:TezosKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/TezosKit/Client/TezosNodeClient.swift
+++ b/TezosKit/Client/TezosNodeClient.swift
@@ -483,7 +483,6 @@ public class TezosNodeClient {
     operationFeePolicy: OperationFeePolicy,
     completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
-    // TODONOT: oepration fees policy
     let undelegateOperation = operationFactory.undelegateOperation(
       source: source,
       operationFeePolicy: operationFeePolicy

--- a/TezosKit/Operation/OperationFactory.swift
+++ b/TezosKit/Operation/OperationFactory.swift
@@ -166,7 +166,6 @@ public class OperationFactory {
 
   // MARK: - Internal
 
-  // TODONOT: Why is fee provider not bound to a protocol?
   private func operationFees(
     from policy: OperationFeePolicy,
     operationKind: OperationKind,

--- a/TezosKit/Operation/OperationFactory.swift
+++ b/TezosKit/Operation/OperationFactory.swift
@@ -24,40 +24,52 @@ public class OperationFactory {
   /// - Parameters:
   ///   - address: The address to reveal.
   ///   - publicKey: The public key of the address to reveal.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
   public func revealOperation(
     from address: Address,
     publicKey: PublicKey,
-    operationFees: OperationFees?
+    operationFeePolicy: OperationFeePolicy
   ) -> Operation {
-    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .reveal, in: tezosProtocol)
-    return RevealOperation(from: address, publicKey: publicKey, operationFees: operationFees)
+    let fees = operationFees(
+      from: operationFeePolicy,
+      operationKind: .reveal,
+      tezosProtocol: tezosProtocol
+    )
+    return RevealOperation(from: address, publicKey: publicKey, operationFees: fees)
   }
 
   /// Create a new origination operation.
   ///
   /// - Parameters:
   ///   - address: The address which will originate the new account.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
   public func originationOperation(
     address: Address,
-    operationFees: OperationFees?
+    operationFeePolicy: OperationFeePolicy
   ) -> Operation {
-    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .origination, in: tezosProtocol)
-    return OriginationOperation(address: address, operationFees: operationFees)
+    let fees = operationFees(
+      from: operationFeePolicy,
+      operationKind: .origination,
+      tezosProtocol: tezosProtocol
+    )
+    return OriginationOperation(address: address, operationFees: fees)
   }
 
   /// Create a delegation operation which will register the given address as a delegate.
   ///
   /// - Parameters:
   ///   - source: The address that will register as a delegate.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
   public func registerDelegateOperation(
     source: Address,
-    operationFees: OperationFees?
+    operationFeePolicy: OperationFeePolicy
   ) -> Operation {
-    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .delegation, in: tezosProtocol)
-    return DelegationOperation(source: source, delegate: source, operationFees: operationFees)
+    let fees = operationFees(
+      from: operationFeePolicy,
+      operationKind: .delegation,
+      tezosProtocol: tezosProtocol
+    )
+    return DelegationOperation(source: source, delegate: source, operationFees: fees)
   }
 
   /// Create a delegation operation which will delegate to the given address.
@@ -65,24 +77,35 @@ public class OperationFactory {
   /// - Parameters:
   ///   - source: The address that will delegate funds.
   ///   - delegate: The address to delegate to.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
   public func delegateOperation(
     source: Address,
     to delegate: Address,
-    operationFees: OperationFees?
+    operationFeePolicy: OperationFeePolicy
   ) -> Operation {
-    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .delegation, in: tezosProtocol)
-    return DelegationOperation(source: source, delegate: delegate, operationFees: operationFees)
+    let fees = operationFees(
+      from: operationFeePolicy,
+      operationKind: .delegation,
+      tezosProtocol: tezosProtocol
+    )
+    return DelegationOperation(source: source, delegate: delegate, operationFees: fees)
   }
 
   /// Create a delegation operation which will clear the delegate from the given address.
   ///
   /// - Parameters:
   ///   - source: The address that will have its delegate cleared.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
-  public func undelegateOperation(source: Address, operationFees: OperationFees?) -> Operation {
-    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .delegation, in: tezosProtocol)
-    return DelegationOperation(source: source, delegate: nil, operationFees: operationFees)
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  public func undelegateOperation(
+    source: Address,
+    operationFeePolicy: OperationFeePolicy
+  ) -> Operation {
+    let fees = operationFees(
+      from: operationFeePolicy,
+      operationKind: .delegation,
+      tezosProtocol: tezosProtocol
+    )
+    return DelegationOperation(source: source, delegate: nil, operationFees: fees)
   }
 
   /// Create a new transaction operation.
@@ -91,19 +114,23 @@ public class OperationFactory {
   ///   - amount: The amount of XTZ to transact.
   ///   - from: The address that is sending the XTZ.
   ///   - to: The address that is receiving the XTZ.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
   public func transactionOperation(
     amount: Tez,
     source: Address,
     destination: Address,
-    operationFees: OperationFees?
+    operationFeePolicy: OperationFeePolicy
   ) -> Operation {
-    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .transaction, in: tezosProtocol)
+    let fees = operationFees(
+      from: operationFeePolicy,
+      operationKind: .transaction,
+      tezosProtocol: tezosProtocol
+    )
     return TransactionOperation(
       amount: amount,
       source: source,
       destination: destination,
-      operationFees: operationFees
+      operationFees: fees
     )
   }
 
@@ -115,21 +142,41 @@ public class OperationFactory {
   ///   - parameter: An optional parameter to send to the smart contract.
   ///   - source: The address invoking the contract.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees.
   public func smartContractInvocationOperation(
     amount: Tez,
     parameter: MichelsonParameter?,
     source: Address,
     destination: Address,
-    operationFees: OperationFees?
+    operationFeePolicy: OperationFeePolicy
   ) -> Operation {
-    let operationFees = operationFees ?? defaultFeeProvider.fees(for: .transaction, in: tezosProtocol)
+    let fees = operationFees(
+      from: operationFeePolicy,
+      operationKind: .transaction,
+      tezosProtocol: tezosProtocol
+    )
     return TransactionOperation(
       amount: amount,
       parameter: parameter,
       source: source,
       destination: destination,
-      operationFees: operationFees
+      operationFees: fees
     )
+  }
+
+  // MARK: - Internal
+
+  // TODONOT: Why is fee provider not bound to a protocol?
+  private func operationFees(
+    from policy: OperationFeePolicy,
+    operationKind: OperationKind,
+    tezosProtocol: TezosProtocol
+  ) -> OperationFees {
+    switch policy {
+    case .default:
+      return defaultFeeProvider.fees(for: operationKind, in: tezosProtocol)
+    case .custom(let operationFees):
+      return operationFees
+    }
   }
 }

--- a/TezosKit/Operation/OperationFeePolicy.swift
+++ b/TezosKit/Operation/OperationFeePolicy.swift
@@ -1,0 +1,12 @@
+// Copyright Keefer Taylor, 2019.
+
+import Foundation
+
+/// A policy that determines how to apply fees on an operation.
+public enum OperationFeePolicy {
+  /// Use the default fees provided by TezosKit.
+  case `default`
+
+  /// Use custom fees in the associated value.
+  case custom(OperationFees)
+}

--- a/TezosKit/RPC/Payload/OperationPayload.swift
+++ b/TezosKit/RPC/Payload/OperationPayload.swift
@@ -47,7 +47,7 @@ public struct OperationPayload {
       let revealOperation = operationFactory.revealOperation(
         from: source,
         publicKey: signatureProvider.publicKey,
-        operationFees: nil
+        operationFeePolicy: .default
       )
       mutableOperations.insert(revealOperation, at: 0)
     }


### PR DESCRIPTION
Create an `OperationFeePolicy` which encapsulates Fee Estimation in TezosKit.

Expose these methods internally, for now. Migrating public methods is a breaking API change and there is not a good reason to migrate until operation estimation is in. 