### PR TITLE
Make OperationFactory methods return optionals

### DIFF
--- a/Extensions/PromiseKit/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNodeClient+Promises.swift
@@ -293,13 +293,19 @@ extension TezosNodeClient {
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy
   ) -> Promise<String> {
-    let transactionOperation = operationFactory.transactionOperation(
-      amount: amount,
-      source: source,
-      destination: recipientAddress,
-      operationFeePolicy: operationFeePolicy,
-      signatureProvider: signatureProvider
-    )
+    guard
+      let transactionOperation = operationFactory.transactionOperation(
+        amount: amount,
+        source: source,
+        destination: recipientAddress,
+        operationFeePolicy: operationFeePolicy,
+        signatureProvider: signatureProvider
+      )
+      else {
+        return Promise { seal in
+          seal.reject(TezosKitError(kind: .transactionFormationFailure))
+        }
+      }
     return forgeSignPreapplyAndInject(
       operation: transactionOperation,
       source: source,
@@ -325,14 +331,21 @@ extension TezosNodeClient {
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy
   ) -> Promise<String> {
-    let smartContractInvocationOperation = operationFactory.smartContractInvocationOperation(
-      amount: amount,
-      parameter: parameter,
-      source: source,
-      destination: contract,
-      operationFeePolicy: operationFeePolicy,
-      signatureProvider: signatureProvider
-    )
+    guard
+      let smartContractInvocationOperation = operationFactory.smartContractInvocationOperation(
+        amount: amount,
+        parameter: parameter,
+        source: source,
+        destination: contract,
+        operationFeePolicy: operationFeePolicy,
+        signatureProvider: signatureProvider
+      )
+    else {
+      return Promise { seal in
+        seal.reject(TezosKitError(kind: .transactionFormationFailure))
+      }
+    }
+
     return forgeSignPreapplyAndInject(
       operation: smartContractInvocationOperation,
       source: source,
@@ -358,12 +371,19 @@ extension TezosNodeClient {
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy
   ) -> Promise<String> {
-    let delegationOperation = operationFactory.delegateOperation(
-      source: source,
-      to: delegate,
-      operationFeePolicy: operationFeePolicy,
-      signatureProvider: signatureProvider
-    )
+    guard
+      let delegationOperation = operationFactory.delegateOperation(
+        source: source,
+        to: delegate,
+        operationFeePolicy: operationFeePolicy,
+        signatureProvider: signatureProvider
+      )
+    else {
+      return Promise { seal in
+        seal.reject(TezosKitError(kind: .transactionFormationFailure))
+      }
+    }
+
     return forgeSignPreapplyAndInject(
       operation: delegationOperation,
       source: source,
@@ -383,11 +403,18 @@ extension TezosNodeClient {
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy
   ) -> Promise<String> {
-    let undelegateOperatoin = operationFactory.undelegateOperation(
-      source: source,
-      operationFeePolicy: operationFeePolicy,
-      signatureProvider: signatureProvider
-    )
+    guard
+      let undelegateOperatoin = operationFactory.undelegateOperation(
+        source: source,
+        operationFeePolicy: operationFeePolicy,
+        signatureProvider: signatureProvider
+      )
+    else {
+      return Promise { seal in
+        seal.reject(TezosKitError(kind: .transactionFormationFailure))
+      }
+    }
+
     return forgeSignPreapplyAndInject(
       operation: undelegateOperatoin,
       source: source,
@@ -407,11 +434,18 @@ extension TezosNodeClient {
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy
   ) -> Promise<String> {
-    let registerDelegateOperation = operationFactory.registerDelegateOperation(
-      source: delegate,
-      operationFeePolicy: operationFeePolicy,
-      signatureProvider: signatureProvider
-    )
+    guard
+      let registerDelegateOperation = operationFactory.registerDelegateOperation(
+        source: delegate,
+        operationFeePolicy: operationFeePolicy,
+        signatureProvider: signatureProvider
+      )
+    else {
+      return Promise { seal in
+        seal.reject(TezosKitError(kind: .transactionFormationFailure))
+      }
+    }
+
     return forgeSignPreapplyAndInject(
       operation: registerDelegateOperation,
       source: delegate,
@@ -431,11 +465,18 @@ extension TezosNodeClient {
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy
   ) -> Promise<String> {
-    let originationOperation = operationFactory.originationOperation(
-      address: managerAddress,
-      operationFeePolicy: operationFeePolicy,
-      signatureProvider: signatureProvider
-    )
+    guard
+      let originationOperation = operationFactory.originationOperation(
+        address: managerAddress,
+        operationFeePolicy: operationFeePolicy,
+        signatureProvider: signatureProvider
+      )
+    else {
+      return Promise { seal in
+        seal.reject(TezosKitError(kind: .transactionFormationFailure))
+      }
+    }
+
     return forgeSignPreapplyAndInject(
       operation: originationOperation,
       source: managerAddress,

--- a/IntegrationTests/Extensions/PromiseKit/TezosNodeIntegrationTests+Promises.swift
+++ b/IntegrationTests/Extensions/PromiseKit/TezosNodeIntegrationTests+Promises.swift
@@ -158,7 +158,7 @@ extension TezosNodeIntegrationTests {
       address: Wallet.testWallet.address,
       operationFeePolicy: .default,
       signatureProvider: Wallet.testWallet
-    )
+    )!
     self.nodeClient.runOperation(operation, from: .testWallet).done { simulationResult in
       guard case .success(let consumedGas, let consumedStorage) = simulationResult else {
         XCTFail()
@@ -208,14 +208,14 @@ extension TezosNodeIntegrationTests {
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5",
         operationFeePolicy: .default,
         signatureProvider: Wallet.testWallet
-      ),
+      )!,
       OperationFactory.testOperationFactory.transactionOperation(
         amount: Tez("2")!,
         source: Wallet.testWallet.address,
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5",
         operationFeePolicy: .default,
         signatureProvider: Wallet.testWallet
-      )
+      )!
     ]
 
     nodeClient.forgeSignPreapplyAndInject(

--- a/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
+++ b/IntegrationTests/TezosKit/TezosNodeIntegrationTests.swift
@@ -291,7 +291,7 @@ class TezosNodeIntegrationTests: XCTestCase {
       address: Wallet.testWallet.address,
       operationFeePolicy: .default,
       signatureProvider: Wallet.testWallet
-    )
+    )!
     self.nodeClient.runOperation(operation, from: .testWallet) { result in
       switch result {
       case .failure(let error):
@@ -321,14 +321,14 @@ class TezosNodeIntegrationTests: XCTestCase {
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5",
         operationFeePolicy: .default,
         signatureProvider: Wallet.testWallet
-      ),
+      )!,
       OperationFactory.testOperationFactory.transactionOperation(
         amount: Tez("2")!,
         source: Wallet.testWallet.address,
         destination: "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5",
         operationFeePolicy: .default,
         signatureProvider: Wallet.testWallet
-      )
+      )!
     ]
 
     nodeClient.forgeSignPreapplyAndInject(

--- a/Tests/TestObjects.swift
+++ b/Tests/TestObjects.swift
@@ -53,7 +53,7 @@ extension OperationPayload {
     operationMetadata: .testOperationMetadata,
     source: .testAddress,
     signatureProvider: FakeSignatureProvider.testSignatureProvider
-  )
+  )!
 }
 
 extension SignedOperationPayload {

--- a/Tests/TezosKit/DelegationOperationTest.swift
+++ b/Tests/TezosKit/DelegationOperationTest.swift
@@ -13,7 +13,7 @@ class DelegationOperationTest: XCTestCase {
       to: delegate,
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])
@@ -30,7 +30,7 @@ class DelegationOperationTest: XCTestCase {
       source: source,
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])
@@ -46,7 +46,7 @@ class DelegationOperationTest: XCTestCase {
       source: source,
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])

--- a/Tests/TezosKit/OperationFactoryTest.swift
+++ b/Tests/TezosKit/OperationFactoryTest.swift
@@ -14,7 +14,7 @@ class OperationFactoryTest: XCTestCase {
       publicKey: FakePublicKey(base58CheckRepresentation: "xyz"),
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     let defaultFees = DefaultFeeProvider.fees(for: .reveal)
     XCTAssertEqual(revealOperation.operationFees.fee, defaultFees.fee)
@@ -27,7 +27,7 @@ class OperationFactoryTest: XCTestCase {
       address: "tz1abc",
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     let defaultFees = DefaultFeeProvider.fees(for: .origination)
     XCTAssertEqual(originationOperation.operationFees.fee, defaultFees.fee)
@@ -42,7 +42,7 @@ class OperationFactoryTest: XCTestCase {
       destination: "tz2xyz",
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     let defaultFees = DefaultFeeProvider.fees(for: .transaction)
     XCTAssertEqual(transactionOperation.operationFees.fee, defaultFees.fee)
@@ -56,7 +56,7 @@ class OperationFactoryTest: XCTestCase {
       to: "tz2xyz",
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     let defaultFees = DefaultFeeProvider.fees(for: .delegation)
     XCTAssertEqual(delegationOperation.operationFees.fee, defaultFees.fee)
@@ -69,7 +69,7 @@ class OperationFactoryTest: XCTestCase {
       source: "tz1abc",
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     let defaultFees = DefaultFeeProvider.fees(for: .delegation)
     XCTAssertEqual(registerDelegateOperation.operationFees.fee, defaultFees.fee)
@@ -82,7 +82,7 @@ class OperationFactoryTest: XCTestCase {
       source: "tz1abc",
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     let defaultFees = DefaultFeeProvider.fees(for: .delegation)
     XCTAssertEqual(clearDelegateOperation.operationFees.fee, defaultFees.fee)
@@ -98,7 +98,7 @@ class OperationFactoryTest: XCTestCase {
       publicKey: FakePublicKey(base58CheckRepresentation: "xyz"),
       operationFeePolicy: .custom(.testFees),
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     XCTAssertEqual(revealOperation.operationFees.fee, OperationFees.testFees.fee)
     XCTAssertEqual(revealOperation.operationFees.gasLimit, OperationFees.testFees.gasLimit)
@@ -110,7 +110,7 @@ class OperationFactoryTest: XCTestCase {
       address: "tz1abc",
       operationFeePolicy: .custom(.testFees),
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     XCTAssertEqual(originationOperation.operationFees.fee, OperationFees.testFees.fee)
     XCTAssertEqual(originationOperation.operationFees.gasLimit, OperationFees.testFees.gasLimit)
@@ -124,7 +124,7 @@ class OperationFactoryTest: XCTestCase {
       destination: "tz2xyz",
       operationFeePolicy: .custom(.testFees),
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     XCTAssertEqual(transactionOperation.operationFees.fee, OperationFees.testFees.fee)
     XCTAssertEqual(transactionOperation.operationFees.gasLimit, OperationFees.testFees.gasLimit)
@@ -137,7 +137,7 @@ class OperationFactoryTest: XCTestCase {
       to: "tz2xyz",
       operationFeePolicy: .custom(.testFees),
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     XCTAssertEqual(delegationOperation.operationFees.fee, OperationFees.testFees.fee)
     XCTAssertEqual(delegationOperation.operationFees.gasLimit, OperationFees.testFees.gasLimit)
@@ -149,7 +149,7 @@ class OperationFactoryTest: XCTestCase {
       source: "tz1abc",
       operationFeePolicy: .custom(.testFees),
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     XCTAssertEqual(registerDelegateOperation.operationFees.fee, OperationFees.testFees.fee)
     XCTAssertEqual(registerDelegateOperation.operationFees.gasLimit, OperationFees.testFees.gasLimit)
@@ -161,7 +161,7 @@ class OperationFactoryTest: XCTestCase {
       source: "tz1abc",
       operationFeePolicy: .custom(.testFees),
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     XCTAssertEqual(clearDelegateOperation.operationFees.fee, OperationFees.testFees.fee)
     XCTAssertEqual(clearDelegateOperation.operationFees.gasLimit, OperationFees.testFees.gasLimit)

--- a/Tests/TezosKit/OperationPayloadTest.swift
+++ b/Tests/TezosKit/OperationPayloadTest.swift
@@ -27,7 +27,7 @@ final class OperationPayloadTest: XCTestCase {
         to: .testDestinationAddress,
         operationFeePolicy: .default,
         signatureProvider: FakeSignatureProvider.testSignatureProvider
-      )
+      )!
     ]
 
     let operationPayload = OperationPayload(
@@ -36,7 +36,7 @@ final class OperationPayloadTest: XCTestCase {
       operationMetadata: operationMetadataWithRevealedKey,
       source: .testAddress,
       signatureProvider: signatureProvider
-    )
+    )!
 
     XCTAssertEqual(operationPayload.operations.count, operations.count)
     verifyOperationCountersInAscendingOrder(
@@ -53,12 +53,12 @@ final class OperationPayloadTest: XCTestCase {
         to: .testDestinationAddress,
         operationFeePolicy: .default,
         signatureProvider: FakeSignatureProvider.testSignatureProvider
-      ),
+      )!,
       operationFactory.registerDelegateOperation(
         source: .testAddress,
         operationFeePolicy: .default,
         signatureProvider: FakeSignatureProvider.testSignatureProvider
-      )
+      )!
     ]
 
     let operationPayload = OperationPayload(
@@ -67,7 +67,7 @@ final class OperationPayloadTest: XCTestCase {
       operationMetadata: operationMetadataWithRevealedKey,
       source: .testAddress,
       signatureProvider: signatureProvider
-    )
+    )!
 
     XCTAssertEqual(operationPayload.operations.count, operations.count)
     verifyOperationCountersInAscendingOrder(
@@ -84,12 +84,12 @@ final class OperationPayloadTest: XCTestCase {
         to: .testDestinationAddress,
         operationFeePolicy: .default,
         signatureProvider: FakeSignatureProvider.testSignatureProvider
-      ),
+      )!,
       operationFactory.registerDelegateOperation(
         source: .testAddress,
         operationFeePolicy: .default,
         signatureProvider: FakeSignatureProvider.testSignatureProvider
-      )
+      )!
     ]
 
     let operationPayload = OperationPayload(
@@ -98,7 +98,7 @@ final class OperationPayloadTest: XCTestCase {
       operationMetadata: operationMetadataWithUnrevealedKey,
       source: .testAddress,
       signatureProvider: signatureProvider
-    )
+    )!
 
     // Expected a reveal operation.
     XCTAssertEqual(operationPayload.operations.count, operations.count + 1)
@@ -117,7 +117,7 @@ final class OperationPayloadTest: XCTestCase {
         publicKey: signatureProvider.publicKey,
         operationFeePolicy: .default,
         signatureProvider: FakeSignatureProvider.testSignatureProvider
-      )
+      )!
     ]
 
     let operationPayload = OperationPayload(
@@ -126,7 +126,7 @@ final class OperationPayloadTest: XCTestCase {
       operationMetadata: operationMetadataWithUnrevealedKey,
       source: .testAddress,
       signatureProvider: signatureProvider
-    )
+    )!
 
     XCTAssertEqual(operationPayload.operations.count, operations.count)
     verifyOperationCountersInAscendingOrder(

--- a/Tests/TezosKit/RevealOperationTest.swift
+++ b/Tests/TezosKit/RevealOperationTest.swift
@@ -13,7 +13,7 @@ class RevealOperationTest: XCTestCase {
       publicKey: publicKey,
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])

--- a/Tests/TezosKit/SimulationServiceTest.swift
+++ b/Tests/TezosKit/SimulationServiceTest.swift
@@ -19,7 +19,7 @@ final class SimulationServiceTest: XCTestCase {
       to: .testDestinationAddress,
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     let simulationCompletionExpectation = XCTestExpectation(description: "Simulation completion called.")
     simulationService.simulate(
@@ -56,7 +56,7 @@ final class SimulationServiceTest: XCTestCase {
       to: .testDestinationAddress,
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
 
     let simulationCompletionExpectation = XCTestExpectation(description: "Simulation completion called.")
     simulationService.simulate(

--- a/Tests/TezosKit/TransactionOperationTest.swift
+++ b/Tests/TezosKit/TransactionOperationTest.swift
@@ -16,7 +16,7 @@ class TransactionOperationTest: XCTestCase {
       destination: .testDestinationAddress,
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])
@@ -39,7 +39,7 @@ class TransactionOperationTest: XCTestCase {
       destination: .testDestinationAddress,
       operationFeePolicy: .default,
       signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )
+    )!
     let dictionary = operation.dictionaryRepresentation
 
     XCTAssertNotNil(dictionary["source"])

--- a/TezosKit/Client/TezosKitError.swift
+++ b/TezosKit/Client/TezosKitError.swift
@@ -11,6 +11,7 @@ public struct TezosKitError: Error {
     case preapplicationError
     case rpcError
     case signingError
+    case transactionFormationFailure
     case unexpectedRequestFormat
     case unexpectedResponse
     case unknown

--- a/TezosKit/Operation/OperationFactory.swift
+++ b/TezosKit/Operation/OperationFactory.swift
@@ -31,7 +31,7 @@ public class OperationFactory {
     publicKey: PublicKey,
     operationFeePolicy: OperationFeePolicy,
     signatureProvider: SignatureProvider
-  ) -> Operation {
+  ) -> Operation? {
     let operation = RevealOperation(from: address, publicKey: publicKey, operationFees: OperationFees.zeroFees)
     let fees = operationFees(
       from: operationFeePolicy,
@@ -54,7 +54,7 @@ public class OperationFactory {
     address: Address,
     operationFeePolicy: OperationFeePolicy,
     signatureProvider: SignatureProvider
-  ) -> Operation {
+  ) -> Operation? {
     let operation = OriginationOperation(address: address, operationFees: OperationFees.zeroFees)
     let fees = operationFees(
       from: operationFeePolicy,
@@ -77,7 +77,7 @@ public class OperationFactory {
     source: Address,
     operationFeePolicy: OperationFeePolicy,
     signatureProvider: SignatureProvider
-  ) -> Operation {
+  ) -> Operation? {
     let operation = DelegationOperation(source: source, delegate: source, operationFees: OperationFees.zeroFees)
     let fees = operationFees(
       from: operationFeePolicy,
@@ -102,7 +102,7 @@ public class OperationFactory {
     to delegate: Address,
     operationFeePolicy: OperationFeePolicy,
     signatureProvider: SignatureProvider
-  ) -> Operation {
+  ) -> Operation? {
     let operation = DelegationOperation(source: source, delegate: delegate, operationFees: OperationFees.zeroFees)
     let fees = operationFees(
       from: operationFeePolicy,
@@ -125,7 +125,7 @@ public class OperationFactory {
     source: Address,
     operationFeePolicy: OperationFeePolicy,
     signatureProvider: SignatureProvider
-  ) -> Operation {
+  ) -> Operation? {
     let operation = DelegationOperation(source: source, delegate: nil, operationFees: OperationFees.zeroFees)
     let fees = operationFees(
       from: operationFeePolicy,
@@ -152,7 +152,7 @@ public class OperationFactory {
     destination: Address,
     operationFeePolicy: OperationFeePolicy,
     signatureProvider: SignatureProvider
-  ) -> Operation {
+  ) -> Operation? {
     let operation = TransactionOperation(
       amount: amount,
       source: source,
@@ -187,7 +187,7 @@ public class OperationFactory {
     destination: Address,
     operationFeePolicy: OperationFeePolicy,
     signatureProvider: SignatureProvider
-  ) -> Operation {
+  ) -> Operation? {
     let operation = TransactionOperation(
       amount: amount,
       parameter: parameter,

--- a/TezosKit/Operation/SimulationService.swift
+++ b/TezosKit/Operation/SimulationService.swift
@@ -53,15 +53,14 @@ public class SimulationService {
         return
       }
 
-      let operationPayload = OperationPayload(
-        operations: [operation],
-        operationFactory: self.operationFactory,
-        operationMetadata: operationMetadata,
-        source: source,
-        signatureProvider: signatureProvider
-      )
-
       guard
+        let operationPayload = OperationPayload(
+          operations: [operation],
+          operationFactory: self.operationFactory,
+          operationMetadata: operationMetadata,
+          source: source,
+          signatureProvider: signatureProvider
+        ),
         let signedOperationPayload = SignedOperationPayload(
           operationPayload: operationPayload,
           signature: SimulationService.defaultSignature

--- a/TezosKit/RPC/Payload/OperationPayload.swift
+++ b/TezosKit/RPC/Payload/OperationPayload.swift
@@ -32,7 +32,7 @@ public struct OperationPayload {
   ///   - operationMetadata: Metadata about the operations.
   ///   - source: The address executing the operations.
   ///   - signatureProvider: The object which will provide the public key.
-  public init(
+  public init?(
     operations: [Operation],
     operationFactory: OperationFactory,
     operationMetadata: OperationMetadata,
@@ -44,12 +44,16 @@ public struct OperationPayload {
     // perform.
     var mutableOperations = operations
     if operationMetadata.key == nil && operations.first(where: { $0.requiresReveal }) != nil {
-      let revealOperation = operationFactory.revealOperation(
-        from: source,
-        publicKey: signatureProvider.publicKey,
-        operationFeePolicy: .default,
-        signatureProvider: signatureProvider
-      )
+      guard
+        let revealOperation = operationFactory.revealOperation(
+          from: source,
+          publicKey: signatureProvider.publicKey,
+          operationFeePolicy: .default,
+          signatureProvider: signatureProvider
+        )
+      else {
+        return nil
+      }
       mutableOperations.insert(revealOperation, at: 0)
     }
 


### PR DESCRIPTION
Preparation for fee estimation.

Fee estimation could fail, resulting in a fail-able operation creation request. 