### PR TITLE
Fixes in Simulation Response Adapter

### DIFF
--- a/Tests/TezosKit/SimulationResultResponseAdapterTest.swift
+++ b/Tests/TezosKit/SimulationResultResponseAdapterTest.swift
@@ -96,8 +96,8 @@ final class SimulationResultResponseAdapterTest: XCTestCase {
       return
     }
 
-    XCTAssertEqual(consumedGas, 11_780)
-    XCTAssertEqual(consumedStorage, 49)
+    XCTAssertEqual(consumedGas, 20_000)
+    XCTAssertEqual(consumedStorage, 0)
   }
 
   func testInternalTransactionS() {
@@ -116,6 +116,6 @@ final class SimulationResultResponseAdapterTest: XCTestCase {
     }
 
     XCTAssertEqual(consumedGas, 733_800)
-    XCTAssertEqual(consumedStorage, 49)
+    XCTAssertEqual(consumedStorage, 17_509)
   }
 }

--- a/Tests/TezosKit/SimulationResultResponseAdapterTest.swift
+++ b/Tests/TezosKit/SimulationResultResponseAdapterTest.swift
@@ -79,4 +79,24 @@ final class SimulationResultResponseAdapterTest: XCTestCase {
       return
     }
   }
+
+  /// A batch transaction.
+  func testBatchTransaction() {
+    let input = "{  \"contents\": [{    \"counter\": \"776970\",    \"fee\": \"1268\",    \"gas_limit\": \"10000\",    \"kind\": \"reveal\",    \"metadata\": {      \"balance_updates\": [{        \"change\": \"-1268\",        \"contract\": \"tz1WwEvjKxdz1EFa6a7HYP14SwZSPGfFnPuc\",        \"kind\": \"contract\"      }, {        \"category\": \"fees\",        \"change\": \"1268\",        \"cycle\": 290,        \"delegate\": \"tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU\",        \"kind\": \"freezer\"      }],      \"operation_result\": {        \"consumed_gas\": \"10000\",        \"status\": \"applied\"}    },    \"public_key\": \"edpkuG12SJVcmdNxWfXKPb24mNXSxFX4jsDPYPG7r5AwqdG5G7aACZ\",    \"source\": \"tz1WwEvjKxdz1EFa6a7HYP14SwZSPGfFnPuc\",\"storage_limit\": \"0\"}, {    \"counter\": \"776971\",    \"delegate\": \"tz1WwEvjKxdz1EFa6a7HYP14SwZSPGfFnPuc\",\"fee\": \"0\", \"gas_limit\": \"800000\", \"kind\": \"delegation\",\"metadata\": {\"balance_updates\": [],\"operation_result\": {\"consumed_gas\": \"10000\",\"status\": \"applied\"}},\"source\": \"tz1WwEvjKxdz1EFa6a7HYP14SwZSPGfFnPuc\",\"storage_limit\": \"60000\"}]}"
+    guard
+      let inputData = input.data(using: .utf8),
+      let simulationResult = SimulationResultResponseAdapter.parse(input: inputData)
+      else {
+        XCTFail()
+        return
+    }
+
+    guard case .success(let consumedGas, let consumedStorage) = simulationResult else {
+      XCTFail()
+      return
+    }
+
+    XCTAssertEqual(consumedGas, 11_780)
+    XCTAssertEqual(consumedStorage, 49)
+  }
 }

--- a/Tests/TezosKit/SimulationResultResponseAdapterTest.swift
+++ b/Tests/TezosKit/SimulationResultResponseAdapterTest.swift
@@ -86,7 +86,7 @@ final class SimulationResultResponseAdapterTest: XCTestCase {
     guard
       let inputData = input.data(using: .utf8),
       let simulationResult = SimulationResultResponseAdapter.parse(input: inputData)
-      else {
+    else {
         XCTFail()
         return
     }
@@ -97,6 +97,25 @@ final class SimulationResultResponseAdapterTest: XCTestCase {
     }
 
     XCTAssertEqual(consumedGas, 11_780)
+    XCTAssertEqual(consumedStorage, 49)
+  }
+
+  func testInternalTransactionS() {
+    let input = "{ \"contents\": [ { \"kind\": \"transaction\", \"source\": \"tz1XarY7qEahQBipuuNZ4vPw9MN6Ldyxv8G3\", \"fee\": \"0\", \"counter\": \"30631\", \"gas_limit\": \"800000\", \"storage_limit\": \"60000\", \"amount\": \"10000000\", \"destination\": \"KT1RrfbcDM5eqho4j4u5EbqbaoEFwBsXA434\", \"parameters\": { \"prim\": \"Right\", \"args\": [ { \"prim\": \"Left\", \"args\": [ { \"prim\": \"Pair\", \"args\": [ { \"int\": \"1\" }, { \"string\": \"2020-06-29T18:00:21Z\" } ] } ] } ] }, \"metadata\": { \"balance_updates\": [], \"operation_result\": { \"status\": \"applied\", \"storage\": { \"prim\": \"Pair\", \"args\": [ [], { \"prim\": \"Pair\", \"args\": [ { \"prim\": \"Pair\", \"args\": [ { \"bytes\": \"019177bfab48c1e9991fca5f7ca6ebe99a1aa5cf5700\" }, { \"bytes\": \"018f090483da68845c926fff0e360a1154266c994b00\" } ] }, { \"prim\": \"Pair\", \"args\": [ { \"int\": \"19352385\" }, [ { \"prim\": \"Elt\", \"args\": [ { \"bytes\": \"00008307c8ce77c8f7ab711c1d3bb3570e5fbe11f5dc\" }, { \"prim\": \"Right\", \"args\": [ { \"prim\": \"Left\", \"args\": [ { \"prim\": \"Pair\", \"args\": [ { \"int\": \"1\" }, { \"int\": \"1593453621\" } ] } ] } ] } ] } ] ] } ] } ] }, \"big_map_diff\": [], \"balance_updates\": [ { \"kind\": \"contract\", \"contract\": \"tz1XarY7qEahQBipuuNZ4vPw9MN6Ldyxv8G3\", \"change\": \"-10000000\" }, { \"kind\": \"contract\", \"contract\": \"KT1RrfbcDM5eqho4j4u5EbqbaoEFwBsXA434\", \"change\": \"10000000\" } ], \"consumed_gas\": \"185075\", \"storage_size\": \"7166\" }, \"internal_operation_results\": [ { \"kind\": \"transaction\", \"source\": \"KT1RrfbcDM5eqho4j4u5EbqbaoEFwBsXA434\", \"nonce\": 0, \"amount\": \"10000000\", \"destination\": \"KT1MqvzsEPoZnbacH18uztqvQdG8x8nKAgFi\", \"parameters\": { \"prim\": \"Left\", \"args\": [ { \"prim\": \"Pair\", \"args\": [ { \"bytes\": \"01bd7bcfca7caa3469dfa1a0bf4863dc8de759de6b00\" }, { \"bytes\": \"018f090483da68845c926fff0e360a1154266c994b00\" } ] } ] }, \"result\": { \"status\": \"applied\", \"storage\": { \"prim\": \"Pair\", \"args\": [ [], { \"prim\": \"Unit\" } ] }, \"big_map_diff\": [ { \"key_hash\": \"exprv3WzhTyQcC4ZmG66wfxsLYy9im9Pe8msAGxnLSdRE16QEvxHhj\", \"key\": { \"bytes\": \"018f090483da68845c926fff0e360a1154266c994b00\" }, \"value\": { \"prim\": \"Pair\", \"args\": [ { \"int\": \"10000000\" }, { \"bytes\": \"01bd7bcfca7caa3469dfa1a0bf4863dc8de759de6b00\" } ] } } ], \"balance_updates\": [ { \"kind\": \"contract\", \"contract\": \"KT1RrfbcDM5eqho4j4u5EbqbaoEFwBsXA434\", \"change\": \"-10000000\" }, { \"kind\": \"contract\", \"contract\": \"KT1MqvzsEPoZnbacH18uztqvQdG8x8nKAgFi\", \"change\": \"10000000\" } ], \"consumed_gas\": \"145880\", \"storage_size\": \"826\" } }, { \"kind\": \"transaction\", \"source\": \"KT1MqvzsEPoZnbacH18uztqvQdG8x8nKAgFi\", \"nonce\": 1, \"amount\": \"0\", \"destination\": \"KT1Md4zkfCvkdqgxAC9tyRYpRUBKmD1owEi2\", \"parameters\": { \"prim\": \"Right\", \"args\": [ { \"bytes\": \"01bd7bcfca7caa3469dfa1a0bf4863dc8de759de6b00\" } ] }, \"result\": { \"status\": \"applied\", \"storage\": { \"prim\": \"Pair\", \"args\": [ [], { \"prim\": \"Pair\", \"args\": [ { \"int\": \"100\" }, { \"prim\": \"Pair\", \"args\": [ { \"string\": \"Tezos Gold\" }, { \"string\": \"TGD\" } ] } ] } ] }, \"big_map_diff\": [], \"consumed_gas\": \"49771\", \"storage_size\": \"784\" } }, { \"kind\": \"transaction\", \"source\": \"KT1Md4zkfCvkdqgxAC9tyRYpRUBKmD1owEi2\", \"nonce\": 2, \"amount\": \"0\", \"destination\": \"KT1MqvzsEPoZnbacH18uztqvQdG8x8nKAgFi\", \"parameters\": { \"prim\": \"Right\", \"args\": [ { \"int\": \"12\" } ] }, \"result\": { \"status\": \"applied\", \"storage\": { \"prim\": \"Pair\", \"args\": [ [], { \"prim\": \"Unit\" } ] }, \"big_map_diff\": [], \"consumed_gas\": \"134614\", \"storage_size\": \"826\" } }, { \"kind\": \"transaction\", \"source\": \"KT1MqvzsEPoZnbacH18uztqvQdG8x8nKAgFi\", \"nonce\": 3, \"amount\": \"10000000\", \"destination\": \"KT1RrfbcDM5eqho4j4u5EbqbaoEFwBsXA434\", \"parameters\": { \"prim\": \"Right\", \"args\": [ { \"prim\": \"Right\", \"args\": [ { \"prim\": \"Right\", \"args\": [ { \"int\": \"12\" } ] } ] } ] }, \"result\": { \"status\": \"applied\", \"storage\": { \"prim\": \"Pair\", \"args\": [ [], { \"prim\": \"Pair\", \"args\": [ { \"prim\": \"Pair\", \"args\": [ { \"bytes\": \"019177bfab48c1e9991fca5f7ca6ebe99a1aa5cf5700\" }, { \"bytes\": \"018f090483da68845c926fff0e360a1154266c994b00\" } ] }, { \"prim\": \"Pair\", \"args\": [ { \"int\": \"19352385\" }, [] ] } ] } ] }, \"big_map_diff\": [], \"balance_updates\": [ { \"kind\": \"contract\", \"contract\": \"KT1MqvzsEPoZnbacH18uztqvQdG8x8nKAgFi\", \"change\": \"-10000000\" }, { \"kind\": \"contract\", \"contract\": \"KT1RrfbcDM5eqho4j4u5EbqbaoEFwBsXA434\", \"change\": \"10000000\" } ], \"consumed_gas\": \"187633\", \"storage_size\": \"7123\" } }, { \"kind\": \"transaction\", \"source\": \"KT1RrfbcDM5eqho4j4u5EbqbaoEFwBsXA434\", \"nonce\": 4, \"amount\": \"0\", \"destination\": \"KT1Md4zkfCvkdqgxAC9tyRYpRUBKmD1owEi2\", \"parameters\": { \"prim\": \"Left\", \"args\": [ { \"prim\": \"Pair\", \"args\": [ { \"bytes\": \"01bd7bcfca7caa3469dfa1a0bf4863dc8de759de6b00\" }, { \"prim\": \"Pair\", \"args\": [ { \"bytes\": \"00008307c8ce77c8f7ab711c1d3bb3570e5fbe11f5dc\" }, { \"int\": \"1\" } ] } ] } ] }, \"result\": { \"status\": \"applied\", \"storage\": { \"prim\": \"Pair\", \"args\": [ [], { \"prim\": \"Pair\", \"args\": [ { \"int\": \"100\" }, { \"prim\": \"Pair\", \"args\": [ { \"string\": \"Tezos Gold\" }, { \"string\": \"TGD\" } ] } ] } ] }, \"big_map_diff\": [ { \"key_hash\": \"exprtoyixHUj8qCQE23RH3AG7ScoFMeafLGxc93M8XZZ4ckJYr2JpQ\", \"key\": { \"bytes\": \"00008307c8ce77c8f7ab711c1d3bb3570e5fbe11f5dc\" }, \"value\": { \"prim\": \"Pair\", \"args\": [ { \"int\": \"58\" }, [] ] } }, { \"key_hash\": \"exprv9SUvRRcsRJRGD8tHmKVbPNxWQ71hK6LNRCXVjkTw8pd8GRkUB\", \"key\": { \"bytes\": \"01bd7bcfca7caa3469dfa1a0bf4863dc8de759de6b00\" }, \"value\": { \"prim\": \"Pair\", \"args\": [ { \"int\": \"11\" }, [] ] } } ], \"consumed_gas\": \"30827\", \"storage_size\": \"784\" } } ] } } ] }"
+    guard
+      let inputData = input.data(using: .utf8),
+      let simulationResult = SimulationResultResponseAdapter.parse(input: inputData)
+      else {
+        XCTFail()
+        return
+    }
+
+    guard case .success(let consumedGas, let consumedStorage) = simulationResult else {
+      XCTFail()
+      return
+    }
+
+    XCTAssertEqual(consumedGas, 733_800)
     XCTAssertEqual(consumedStorage, 49)
   }
 }

--- a/TezosKit/RPC/ResponseAdapters/SimulationResultResponseAdapter.swift
+++ b/TezosKit/RPC/ResponseAdapters/SimulationResultResponseAdapter.swift
@@ -7,8 +7,10 @@ private enum JSON {
   public enum Keys {
     public static let consumedGas = "consumed_gas"
     public static let contents = "contents"
+    public static let internalOperationResult = "internal_operation_results"
     public static let metadata = "metadata"
     public static let operationResult = "operation_result"
+    public static let result = "result"
     public static let status = "status"
     public static let storageSize = "storage_size"
   }
@@ -23,31 +25,55 @@ public class SimulationResultResponseAdapter: AbstractResponseAdapter<Simulation
   public override class func parse(input: Data) -> SimulationResult? {
     guard
       let json = JSONDictionaryResponseAdapter.parse(input: input)
-      else {
+    else {
         return nil
     }
 
     guard
-      let contents = json[JSON.Keys.contents] as? [[ String: Any ]],
-      contents.count == 1,
-      let firstContent = contents.first,
-      let metadata = firstContent[JSON.Keys.metadata] as? [String: Any],
-      let operationResult = metadata[JSON.Keys.operationResult] as? [String: Any],
-      let status = operationResult[JSON.Keys.status] as? String
+      let contents = json[JSON.Keys.contents] as? [[ String: Any ]]
       else {
         return nil
     }
 
-    if status == JSON.Values.failed {
-      return .failure
+    var consumedGas = 0
+    var consumedStorage = 0
+    for content in contents {
+      guard
+        let metadata = content[JSON.Keys.metadata] as? [String: Any],
+        let operationResult = metadata[JSON.Keys.operationResult] as? [String: Any],
+        let status = operationResult[JSON.Keys.status] as? String
+        else {
+          continue
+      }
+
+      if status == JSON.Values.failed {
+        return .failure
+      }
+
+      let rawConsumedGas = operationResult[JSON.Keys.consumedGas] as? String ?? "0"
+      consumedGas += Int(rawConsumedGas) ?? 0
+
+      let rawConsumedStorage = operationResult[JSON.Keys.storageSize] as? String ?? "0"
+      consumedStorage += Int(rawConsumedStorage) ?? 0
+
+      if let internalOperationResults = metadata[JSON.Keys.internalOperationResult] as? [[String: Any]] {
+        for internalOperation in internalOperationResults {
+          guard let intenalOperationResult = internalOperation[JSON.Keys.result] as? [String: Any] else {
+            continue
+          }
+
+          let rawInternalConsumedGas = intenalOperationResult[JSON.Keys.consumedGas] as? String ?? "0"
+          let internalConsumedGas = Int(rawInternalConsumedGas) ?? 0
+          consumedGas += internalConsumedGas
+
+          let rawInternalConsumedStorage = intenalOperationResult[JSON.Keys.storageSize] as? String ?? "0"
+          let internalConsumedStorage = Int(rawInternalConsumedStorage) ?? 0
+          consumedStorage += internalConsumedStorage
+        }
+      }
     }
-
-    let rawConsumedGas = operationResult[JSON.Keys.consumedGas] as? String ?? "0"
-    let consumedGas = Int(rawConsumedGas) ?? 0
-
-    let rawConsumedStorage = operationResult[JSON.Keys.storageSize] as? String ?? "0"
-    let consumedStorage = Int(rawConsumedStorage) ?? 0
 
     return .success(consumedGas: consumedGas, consumedStorage: consumedStorage)
   }
 }
+

--- a/TezosKit/RPC/ResponseAdapters/SimulationResultResponseAdapter.swift
+++ b/TezosKit/RPC/ResponseAdapters/SimulationResultResponseAdapter.swift
@@ -76,4 +76,3 @@ public class SimulationResultResponseAdapter: AbstractResponseAdapter<Simulation
     return .success(consumedGas: consumedGas, consumedStorage: consumedStorage)
   }
 }
-

--- a/TezosKit/RPC/ResponseAdapters/SimulationResultResponseAdapter.swift
+++ b/TezosKit/RPC/ResponseAdapters/SimulationResultResponseAdapter.swift
@@ -23,8 +23,8 @@ public class SimulationResultResponseAdapter: AbstractResponseAdapter<Simulation
   public override class func parse(input: Data) -> SimulationResult? {
     guard
       let json = JSONDictionaryResponseAdapter.parse(input: input)
-    else {
-      return nil
+      else {
+        return nil
     }
 
     guard
@@ -34,8 +34,8 @@ public class SimulationResultResponseAdapter: AbstractResponseAdapter<Simulation
       let metadata = firstContent[JSON.Keys.metadata] as? [String: Any],
       let operationResult = metadata[JSON.Keys.operationResult] as? [String: Any],
       let status = operationResult[JSON.Keys.status] as? String
-    else {
-      return nil
+      else {
+        return nil
     }
 
     if status == JSON.Values.failed {


### PR DESCRIPTION
Make SimulationResponseAdapter a bit more resilient to operation types:
- `contents` object has one object per operation, don't assume that only one operation exists.
- SmartContracts have internal operations, gas / storage should be accumulated from these as well

Add unit tests. 