### PR TITLE
Expose OperationFeePolicy APIs

### DIFF
--- a/Extensions/PromiseKit/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNodeClient+Promises.swift
@@ -133,6 +133,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func send(
     amount: Tez,
     to recipientAddress: String,
@@ -164,6 +165,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func call(
     contract: Address,
     amount: Tez = Tez.zeroBalance,
@@ -199,6 +201,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func delegate(
     from source: Address,
     to delegate: Address,
@@ -220,6 +223,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func undelegate(
     from source: Address,
     signatureProvider: SignatureProvider,
@@ -240,6 +244,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func registerDelegate(
     delegate: Address,
     signatureProvider: SignatureProvider,
@@ -260,6 +265,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func originateAccount(
     managerAddress: String,
     signatureProvider: SignatureProvider,
@@ -286,7 +292,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
-  internal func send(
+  public func send(
     amount: Tez,
     to recipientAddress: String,
     from source: Address,
@@ -323,7 +329,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
-  internal func call(
+  public func call(
     contract: Address,
     amount: Tez = Tez.zeroBalance,
     parameter: MichelsonParameter? = nil,
@@ -365,7 +371,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
-  internal func delegate(
+  public func delegate(
     from source: Address,
     to delegate: Address,
     signatureProvider: SignatureProvider,
@@ -398,7 +404,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
-  internal func undelegate(
+  public func undelegate(
     from source: Address,
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy
@@ -429,7 +435,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
-  internal func registerDelegate(
+  public func registerDelegate(
     delegate: Address,
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy
@@ -460,7 +466,7 @@ extension TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
-  internal func originateAccount(
+  public func originateAccount(
     managerAddress: String,
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy

--- a/Extensions/PromiseKit/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNodeClient+Promises.swift
@@ -290,14 +290,14 @@ extension TezosNodeClient {
   ///   - recipientAddress: The address which will receive the Tez.
   ///   - source: The address sending the balance.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
   public func send(
     amount: Tez,
     to recipientAddress: String,
     from source: Address,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy
+    operationFeePolicy: OperationFeePolicy = .default
   ) -> Promise<String> {
     guard
       let transactionOperation = operationFactory.transactionOperation(
@@ -326,7 +326,7 @@ extension TezosNodeClient {
   ///   - amount: The amount of Tez to transfer with the invocation. Default is 0.
   ///   - parameter: An optional parameter to send to the smart contract. Default is none.
   ///   - source: The address invoking the contract.
-  ///   - signatureProvider: The object which will sign the operation.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
   public func call(
@@ -335,7 +335,7 @@ extension TezosNodeClient {
     parameter: MichelsonParameter? = nil,
     source: Address,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy
+    operationFeePolicy: OperationFeePolicy = .default
   ) -> Promise<String> {
     guard
       let smartContractInvocationOperation = operationFactory.smartContractInvocationOperation(
@@ -369,13 +369,13 @@ extension TezosNodeClient {
   ///   - source: The address which will delegate.
   ///   - delegate: The address which will receive the delegation.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
   public func delegate(
     from source: Address,
     to delegate: Address,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy
+    operationFeePolicy: OperationFeePolicy = .default
   ) -> Promise<String> {
     guard
       let delegationOperation = operationFactory.delegateOperation(
@@ -402,12 +402,12 @@ extension TezosNodeClient {
   /// - Parameters:
   ///   - source: The address which is removing the delegate.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
   public func undelegate(
     from source: Address,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy
+    operationFeePolicy: OperationFeePolicy = .default
   ) -> Promise<String> {
     guard
       let undelegateOperatoin = operationFactory.undelegateOperation(
@@ -433,12 +433,12 @@ extension TezosNodeClient {
   /// - Parameters:
   ///   - delegate: The address registering as a delegate.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
   public func registerDelegate(
     delegate: Address,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy
+    operationFeePolicy: OperationFeePolicy = .default
   ) -> Promise<String> {
     guard
       let registerDelegateOperation = operationFactory.registerDelegateOperation(
@@ -464,12 +464,12 @@ extension TezosNodeClient {
   /// - Parameters:
   ///   - managerAddress: The address which will manage the new account.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   /// - Returns: A promise which resolves to a string representing the transaction hash.
   public func originateAccount(
     managerAddress: String,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy
+    operationFeePolicy: OperationFeePolicy = .default
   ) -> Promise<String> {
     guard
       let originationOperation = operationFactory.originationOperation(
@@ -503,7 +503,7 @@ extension TezosNodeClient {
     operation: Operation,
     source: Address,
     signatureProvider: SignatureProvider
-    ) -> Promise<String> {
+  ) -> Promise<String> {
     return Promise { seal in
       forgeSignPreapplyAndInject([operation], source: source, signatureProvider: signatureProvider) { result in
         switch result {

--- a/TezosKit/Client/TezosNodeClient.swift
+++ b/TezosKit/Client/TezosNodeClient.swift
@@ -273,6 +273,7 @@ public class TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   ///   - completion: A completion block called with an optional transaction hash and error.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func send(
     amount: Tez,
     to recipientAddress: String,
@@ -305,7 +306,7 @@ public class TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   ///   - completion: A completion block called with an optional transaction hash and error.
-  internal func send(
+  public func send(
     amount: Tez,
     to recipientAddress: String,
     from source: Address,
@@ -345,6 +346,7 @@ public class TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   ///   - completion: A completion block called with an optional transaction hash and error.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func call(
     contract: Address,
     amount: Tez = Tez.zeroBalance,
@@ -380,7 +382,7 @@ public class TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   ///   - completion: A completion block called with an optional transaction hash and error.
-  internal func call(
+  public func call(
     contract: Address,
     amount: Tez = Tez.zeroBalance,
     parameter: MichelsonParameter? = nil,
@@ -424,6 +426,7 @@ public class TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   ///   - completion: A completion block called with an optional transaction hash and error.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func delegate(
     from source: Address,
     to delegate: Address,
@@ -457,7 +460,7 @@ public class TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   ///   - completion: A completion block called with an optional transaction hash and error.
-  internal func delegate(
+  public func delegate(
     from source: Address,
     to delegate: Address,
     signatureProvider: SignatureProvider,
@@ -494,6 +497,7 @@ public class TezosNodeClient {
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   ///   - completion: A completion block which will be called with a string representing the transaction ID hash if the
   ///                 operation was successful.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func undelegate(
     from source: Address,
     signatureProvider: SignatureProvider,
@@ -516,7 +520,7 @@ public class TezosNodeClient {
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   ///   - completion: A completion block which will be called with a string representing the transaction ID hash if the
   ///                 operation was successful.
-  internal func undelegate(
+  public func undelegate(
     from source: Address,
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy,
@@ -549,6 +553,7 @@ public class TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   ///   - completion: A completion block called with an optional transaction hash and error.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func registerDelegate(
     delegate: Address,
     signatureProvider: SignatureProvider,
@@ -575,7 +580,7 @@ public class TezosNodeClient {
   ///   - signatureProvider: The object which will sign the operation.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   ///   - completion: A completion block called with an optional transaction hash and error.
-  internal func registerDelegate(
+  public func registerDelegate(
     delegate: Address,
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy,
@@ -610,6 +615,7 @@ public class TezosNodeClient {
   ///   - operationFees: OperationFees for the transaction. If nil, default fees are used.
   ///   - completion: A completion block which will be called with a string representing the transaction ID hash if the
   ///                 operation was successful.
+  @available(*, deprecated, message: "Please use an OperationFeePolicy API instead.")
   public func originateAccount(
     managerAddress: String,
     signatureProvider: SignatureProvider,
@@ -637,7 +643,7 @@ public class TezosNodeClient {
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
   ///   - completion: A completion block which will be called with a string representing the transaction ID hash if the
   ///                 operation was successful.
-  internal func originateAccount(
+  public func originateAccount(
     managerAddress: String,
     signatureProvider: SignatureProvider,
     operationFeePolicy: OperationFeePolicy,

--- a/TezosKit/Client/TezosNodeClient.swift
+++ b/TezosKit/Client/TezosNodeClient.swift
@@ -304,14 +304,14 @@ public class TezosNodeClient {
   ///   - recipientAddress: The address which will receive the Tez.
   ///   - source: The address sending the balance.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   ///   - completion: A completion block called with an optional transaction hash and error.
   public func send(
     amount: Tez,
     to recipientAddress: String,
     from source: Address,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy,
+    operationFeePolicy: OperationFeePolicy = .default,
     completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     guard
@@ -380,7 +380,7 @@ public class TezosNodeClient {
   ///   - parameter: An optional parameter to send to the smart contract. Default is none.
   ///   - source: The address invoking the contract.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   ///   - completion: A completion block called with an optional transaction hash and error.
   public func call(
     contract: Address,
@@ -388,7 +388,7 @@ public class TezosNodeClient {
     parameter: MichelsonParameter? = nil,
     source: Address,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy,
+    operationFeePolicy: OperationFeePolicy = .default,
     completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     guard
@@ -458,13 +458,13 @@ public class TezosNodeClient {
   ///   - source: The address which will delegate.
   ///   - delegate: The address which will receive the delegation.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   ///   - completion: A completion block called with an optional transaction hash and error.
   public func delegate(
     from source: Address,
     to delegate: Address,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy,
+    operationFeePolicy: OperationFeePolicy = .default,
     completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     guard
@@ -517,13 +517,13 @@ public class TezosNodeClient {
   /// - Parameters:
   ///   - source: The address which is removing the delegate.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   ///   - completion: A completion block which will be called with a string representing the transaction ID hash if the
   ///                 operation was successful.
   public func undelegate(
     from source: Address,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy,
+    operationFeePolicy: OperationFeePolicy = .default,
     completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     guard
@@ -578,12 +578,12 @@ public class TezosNodeClient {
   /// - Parameters:
   ///   - delegate: The address registering as a delegate.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   ///   - completion: A completion block called with an optional transaction hash and error.
   public func registerDelegate(
     delegate: Address,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy,
+    operationFeePolicy: OperationFeePolicy = .default,
     completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     guard
@@ -640,13 +640,13 @@ public class TezosNodeClient {
   /// - Parameters:
   ///   - managerAddress: The address which will manage the new account.
   ///   - signatureProvider: The object which will sign the operation.
-  ///   - operationFeePolicy: A policy to apply when determining operation fees.
+  ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   ///   - completion: A completion block which will be called with a string representing the transaction ID hash if the
   ///                 operation was successful.
   public func originateAccount(
     managerAddress: String,
     signatureProvider: SignatureProvider,
-    operationFeePolicy: OperationFeePolicy,
+    operationFeePolicy: OperationFeePolicy = .default,
     completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     guard


### PR DESCRIPTION
OperationFeePolicy allows users to choose a default fee, a custom fee, or let TezosKit estimate their fee for them.

Deprecate existing OperationFees APIs, as these are less flexible and are already bridged to the new APIs.