### PR TITLE
[Babylon] Fix Manager Key RPC

### DIFF
--- a/Extensions/PromiseKit/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNodeClient+Promises.swift
@@ -49,7 +49,7 @@ extension TezosNodeClient {
   }
 
   /// Retrieve the address manager key for the given address.
-  public func getAddressManagerKey(address: Address) -> Promise<[String: Any]> {
+  public func getAddressManagerKey(address: Address) -> Promise<String> {
     let rpc = GetAddressManagerKeyRPC(address: address)
     return networkClient.send(rpc)
   }

--- a/Tests/Common/TestObjects.swift
+++ b/Tests/Common/TestObjects.swift
@@ -18,7 +18,6 @@ extension String {
   public static let testForgeResult = "test_forge_result"
   public static let testPublicKey = "edpk_test"
   public static let testSignedBytesForInjection = "abc123edsigxyz789"
-  public static let testManagerKeyResponse = "edpktest"
 }
 
 extension Int {
@@ -161,7 +160,7 @@ extension FakeNetworkClient {
   private static let tezosNodeClientEndpointToResponseMap = [
     "/chains/main/blocks/xyz/helpers/forge/operations": JSONUtils.jsonString(for: .testForgeResult)!,
     "/chains/main/blocks/head/context/contracts/" + .testAddress + "/counter": JSONUtils.jsonString(for: Int.testAddressCounter)!,
-    "/chains/main/blocks/head/context/contracts/" + .testAddress + "/manager_key": JSONUtils.jsonString(for: .testManagerKeyResponse)!,
+    "/chains/main/blocks/head/context/contracts/" + .testAddress + "/manager_key": JSONUtils.jsonString(for: .testPublicKey)!,
     "/chains/main/blocks/head": JSONUtils.jsonString(for: .headResponse)!,
     "/chains/main/blocks/" + .testBranch + "/helpers/preapply/operations": "[{\"contents\":[{\"kind\":\"transaction\",\"source\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"fee\":\"1272\",\"counter\":\"30801\",\"gas_limit\":\"10100\",\"storage_limit\":\"257\",\"amount\":\"1\",\"destination\":\"tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5\",\"metadata\":{\"balance_updates\":[{\"kind\":\"contract\",\"contract\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"change\":\"-1272\"},{\"kind\":\"freezer\",\"category\":\"fees\",\"delegate\":\"tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU\",\"level\":125,\"change\":\"1272\"}],\"operation_result\":{\"status\":\"applied\",\"balance_updates\":[{\"kind\":\"contract\",\"contract\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"change\":\"-1\"},{\"kind\":\"contract\",\"contract\":\"tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5\",\"change\":\"1\"}],\"consumed_gas\":\"10100\"}}}],\"signature\":\"edsigtpsh2VpWyZTZ46q9j54VfsWZLZuxL7UGEhfgCNx6SXwaWu4gMHx59bRdogbSmDCCpXeQeighgpHk5x32k3rtFu8w5EZyEr\"}]\n",
     "/chains/main/blocks/head/helpers/scripts/run_operation": "{\"contents\":[{\"kind\":\"origination\",\"source\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"fee\":\"1265\",\"counter\":\"31038\",\"gas_limit\":\"10000\",\"storage_limit\":\"257\",\"manager_pubkey\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"balance\":\"0\",\"metadata\":{\"balance_updates\":[{\"kind\":\"contract\",\"contract\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"change\":\"-1265\"},{\"kind\":\"freezer\",\"category\":\"fees\",\"delegate\":\"tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU\",\"cycle\":247,\"change\":\"1265\"}],\"operation_result\":{\"status\":\"applied\",\"balance_updates\":[{\"kind\":\"contract\",\"contract\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"change\":\"-257000\"}],\"originated_contracts\":[\"KT1RAHAXehUNusndqZpcxM8SfCjLi83utZsR\"],\"consumed_gas\":\"10000\"}}}]}\n",

--- a/Tests/Common/TestObjects.swift
+++ b/Tests/Common/TestObjects.swift
@@ -18,6 +18,7 @@ extension String {
   public static let testForgeResult = "test_forge_result"
   public static let testPublicKey = "edpk_test"
   public static let testSignedBytesForInjection = "abc123edsigxyz789"
+  public static let testManagerKeyResponse = "edpktest"
 }
 
 extension Int {
@@ -148,9 +149,6 @@ extension OperationMetadataProvider {
 }
 
 extension Dictionary where Key == String, Value == String {
-  public static let managerKeyResponse: [String: String] = [
-    OperationMetadataProvider.JSON.Keys.key: .testPublicKey
-  ]
   public static let headResponse: [String: String]  = [
     OperationMetadataProvider.JSON.Keys.protocol: .testProtocol,
     OperationMetadataProvider.JSON.Keys.hash: .testBranch
@@ -163,7 +161,7 @@ extension FakeNetworkClient {
   private static let tezosNodeClientEndpointToResponseMap = [
     "/chains/main/blocks/xyz/helpers/forge/operations": JSONUtils.jsonString(for: .testForgeResult)!,
     "/chains/main/blocks/head/context/contracts/" + .testAddress + "/counter": JSONUtils.jsonString(for: Int.testAddressCounter)!,
-    "/chains/main/blocks/head/context/contracts/" + .testAddress + "/manager_key": JSONUtils.jsonString(for: .managerKeyResponse)!,
+    "/chains/main/blocks/head/context/contracts/" + .testAddress + "/manager_key": JSONUtils.jsonString(for: .testManagerKeyResponse)!,
     "/chains/main/blocks/head": JSONUtils.jsonString(for: .headResponse)!,
     "/chains/main/blocks/" + .testBranch + "/helpers/preapply/operations": "[{\"contents\":[{\"kind\":\"transaction\",\"source\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"fee\":\"1272\",\"counter\":\"30801\",\"gas_limit\":\"10100\",\"storage_limit\":\"257\",\"amount\":\"1\",\"destination\":\"tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5\",\"metadata\":{\"balance_updates\":[{\"kind\":\"contract\",\"contract\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"change\":\"-1272\"},{\"kind\":\"freezer\",\"category\":\"fees\",\"delegate\":\"tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU\",\"level\":125,\"change\":\"1272\"}],\"operation_result\":{\"status\":\"applied\",\"balance_updates\":[{\"kind\":\"contract\",\"contract\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"change\":\"-1\"},{\"kind\":\"contract\",\"contract\":\"tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5\",\"change\":\"1\"}],\"consumed_gas\":\"10100\"}}}],\"signature\":\"edsigtpsh2VpWyZTZ46q9j54VfsWZLZuxL7UGEhfgCNx6SXwaWu4gMHx59bRdogbSmDCCpXeQeighgpHk5x32k3rtFu8w5EZyEr\"}]\n",
     "/chains/main/blocks/head/helpers/scripts/run_operation": "{\"contents\":[{\"kind\":\"origination\",\"source\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"fee\":\"1265\",\"counter\":\"31038\",\"gas_limit\":\"10000\",\"storage_limit\":\"257\",\"manager_pubkey\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"balance\":\"0\",\"metadata\":{\"balance_updates\":[{\"kind\":\"contract\",\"contract\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"change\":\"-1265\"},{\"kind\":\"freezer\",\"category\":\"fees\",\"delegate\":\"tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU\",\"cycle\":247,\"change\":\"1265\"}],\"operation_result\":{\"status\":\"applied\",\"balance_updates\":[{\"kind\":\"contract\",\"contract\":\"tz1XVJ8bZUXs7r5NV8dHvuiBhzECvLRLR3jW\",\"change\":\"-257000\"}],\"originated_contracts\":[\"KT1RAHAXehUNusndqZpcxM8SfCjLi83utZsR\"],\"consumed_gas\":\"10000\"}}}]}\n",

--- a/Tests/UnitTests/TezosKit/OperationMetadataProviderTest.swift
+++ b/Tests/UnitTests/TezosKit/OperationMetadataProviderTest.swift
@@ -64,7 +64,7 @@ final class OperationMetadataProviderTests: XCTestCase {
   func testOperationMetadataWithMissingManagerKey() {
     let networkClient = FakeNetworkClient.tezosNodeNetworkClient.copy() as! FakeNetworkClient
     let endpoint = "/chains/main/blocks/head/context/contracts/" + .testAddress + "/manager_key"
-    networkClient.endpointToResponseMap[endpoint] = "nonsense"
+    networkClient.endpointToResponseMap[endpoint] = "null"
     let operationMetadataProvider = OperationMetadataProvider(networkClient: networkClient)
 
     let completionCalledExpection = XCTestExpectation()

--- a/TezosKit/Client/TezosNodeClient.swift
+++ b/TezosKit/Client/TezosNodeClient.swift
@@ -200,7 +200,7 @@ public class TezosNodeClient {
   /// Retrieve the address manager key for the given address.
   public func getAddressManagerKey(
     address: Address,
-    completion: @escaping (Result<[String: Any], TezosKitError>) -> Void
+    completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     let rpc = GetAddressManagerKeyRPC(address: address)
     networkClient.send(rpc, completion: completion)

--- a/TezosKit/Operation/OperationMetadataProvider.swift
+++ b/TezosKit/Operation/OperationMetadataProvider.swift
@@ -7,7 +7,6 @@ public class OperationMetadataProvider {
   internal enum JSON {
     public enum Keys {
       public static let hash = "hash"
-      public static let key = "key"
       public static let `protocol` = "protocol"
     }
   }
@@ -158,10 +157,7 @@ public class OperationMetadataProvider {
       switch result {
       case .failure:
         break
-      case .success(let fetchedManagerAndKey):
-        guard let fetchedKey = fetchedManagerAndKey[OperationMetadataProvider.JSON.Keys.key] as? String else {
-          break
-        }
+      case .success(let fetchedKey):
         completion(fetchedKey)
         return
       }

--- a/TezosKit/RPC/GetAddressManagerKeyRPC.swift
+++ b/TezosKit/RPC/GetAddressManagerKeyRPC.swift
@@ -3,10 +3,10 @@
 import Foundation
 
 /// An RPC that will retrieve the manager key of a given address.
-public class GetAddressManagerKeyRPC: RPC<[String: Any]> {
+public class GetAddressManagerKeyRPC: RPC<String> {
   /// - Parameter address: The address to retrieve info about.
   public init(address: Address) {
     let endpoint = "/chains/main/blocks/head/context/contracts/" + address + "/manager_key"
-    super.init(endpoint: endpoint, responseAdapterClass: JSONDictionaryResponseAdapter.self)
+    super.init(endpoint: endpoint, responseAdapterClass: StringResponseAdapter.self)
   }
 }

--- a/TezosKit/RPC/ResponseAdapters/StringResponseAdapter.swift
+++ b/TezosKit/RPC/ResponseAdapters/StringResponseAdapter.swift
@@ -8,7 +8,11 @@ import Foundation
 /// These characters are stripped by this adapter.
 public class StringResponseAdapter: AbstractResponseAdapter<String> {
   public override class func parse(input: Data) -> String? {
-    guard let decodedString = String(data: input, encoding: .utf8) else {
+    guard
+      let decodedString = String(data: input, encoding: .utf8),
+      // RPC API will just pass through `null` when response is not found.
+      decodedString != "null"
+    else {
       return nil
     }
 


### PR DESCRIPTION
RPC now returns a string rather than a dictionary. 

Example: https://tezos-dev.cryptonomic-infra.tech/chains/main/blocks/head/context/contracts/tz1iAFryL7tSyJj8JSMbnCWtFqNVNuNDbbqs/manager_key

Note that unrevealed keys now return null:
https://tezos-dev.cryptonomic-infra.tech/chains/main/blocks/head/context/contracts/tz1VxS7ff4YnZRs8b4mMP4WaMVpoQjuo1rjf/manager_key

Force string response adapter to consider `null` as a failed value, since other RPCs may behave the same way. 