### PR TITLE
[Babylon] Add `chainID` to `OperationMetadata`

### DIFF
--- a/Tests/Common/TestObjects.swift
+++ b/Tests/Common/TestObjects.swift
@@ -9,6 +9,7 @@ import TezosCrypto
 
 extension String {
   public static let testBranch = "xyz"
+  public static let testChainID = "testChainID"
   public static let testProtocol = "alpha"
   public static let testSignature = "edsigabc123"
   public static let testAddress = "tz1abc123xyz"
@@ -34,6 +35,7 @@ extension Array where Element == UInt8 {
 
 extension OperationMetadata {
   public static let testOperationMetadata = OperationMetadata(
+    chainID: .testChainID,
     branch: .testBranch,
     protocol: .testProtocol,
     addressCounter: .testAddressCounter,

--- a/Tests/Common/TestObjects.swift
+++ b/Tests/Common/TestObjects.swift
@@ -152,7 +152,8 @@ extension OperationMetadataProvider {
 extension Dictionary where Key == String, Value == String {
   public static let headResponse: [String: String]  = [
     OperationMetadataProvider.JSON.Keys.protocol: .testProtocol,
-    OperationMetadataProvider.JSON.Keys.hash: .testBranch
+    OperationMetadataProvider.JSON.Keys.hash: .testBranch,
+    OperationMetadataProvider.JSON.Keys.chainID: .testChainID
   ]
 }
 

--- a/Tests/UnitTests/TezosKit/OperationPayloadFactoryTest.swift
+++ b/Tests/UnitTests/TezosKit/OperationPayloadFactoryTest.swift
@@ -6,12 +6,14 @@ import XCTest
 final class OperationPayloadFactoryTest: XCTestCase {
   let signatureProvider = FakeSignatureProvider(signature: .testSignature, publicKey: FakePublicKey.testPublicKey)
   let operationMetadataWithRevealedKey = OperationMetadata(
+    chainID: .testChainID,
     branch: .testBranch,
     protocol: .testProtocol,
     addressCounter: .testAddressCounter,
     key: .testPublicKey
   )
   let operationMetadataWithUnrevealedKey = OperationMetadata(
+    chainID: .testChainID,
     branch: .testBranch,
     protocol: .testProtocol,
     addressCounter: .testAddressCounter,

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -8,110 +8,97 @@
 
 /* Begin PBXBuildFile section */
 		0027D7C06216CECED19E3810 /* OperationMetadataProviderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67BF17864BD54D09DB6CE2FA /* OperationMetadataProviderTest.swift */; };
+		003826423B0CED390C5BFF08 /* RPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A02A5F41589CD0850ED45F8 /* RPC.swift */; };
+		00A736FA9438F4C332A56A3C /* ForgingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99191D08E7D0F08C52254D6B /* ForgingPolicy.swift */; };
 		01659C2FAF425F9B1284CDB1 /* GetAddressBalanceRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1D2B885A5A1D1477E020C5 /* GetAddressBalanceRPCTest.swift */; };
-		01F8923B93419159E3CBE612 /* Tez.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9B3CAED5792E4AB7750AF7 /* Tez.swift */; };
-		0394FB37475676AEA4EF45E4 /* TezosProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DF562D0F0EB275D1CDF473 /* TezosProtocol.swift */; };
-		0398E107F5198C1557D9F02F /* OperationFeePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC90AB66610CCED41A30ED13 /* OperationFeePolicy.swift */; };
 		03CEFD213AC691D632D90FAF /* GetChainHeadHashRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFED1AB3870A0537888D39E /* GetChainHeadHashRPCTest.swift */; };
-		04AE8D3127CA774D4DF2A74B /* IntegerResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CA4FAC6E902A5E05242E80 /* IntegerResponseAdapter.swift */; };
-		04E7EC6DACED48AB20774FDB /* LeftMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C8ED8DF8D7C503E41656D3 /* LeftMichelsonParameter.swift */; };
-		06B484024F2425DF7782BE41 /* OperationPayloadFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2B5D0CAE285FAC9FE43EE3 /* OperationPayloadFactory.swift */; };
+		05242C7AF25D0B6C351BC765 /* GetOriginatedContractsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7008A9105E3151B6B23496F1 /* GetOriginatedContractsRPC.swift */; };
+		053802B930B6B511932F2912 /* SomeMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB80D50511873CF9783361B4 /* SomeMichelsonParameter.swift */; };
 		078DB916D5C442FBEAF6C207 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AC64BA50EF400CF4B90951AA /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		083E6F479F724D868A0513C0 /* JSONUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17556CA46001F8FB5DF8302 /* JSONUtils.swift */; };
-		089431F1BFBDF2DA911267FD /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CD16AED7E1BA31C1679402 /* NetworkClient.swift */; };
-		0A193A2B03ADD8C481FEC5C5 /* GetAddressBalanceRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2482509F6BCADAE0E05A6F6B /* GetAddressBalanceRPC.swift */; };
-		0A7516411990C82E2B7F45CC /* PeriodKindResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B9FDBEACF232BA4330A518 /* PeriodKindResponseAdapter.swift */; };
-		0AD2208F99DFF907337836C5 /* GetProposalsListRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37D3CF0B119086AAA9239B4 /* GetProposalsListRPC.swift */; };
+		09EDCDEF232C8F10CADD8ACD /* OperationFeePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207E6BD1F08A190CAD16F7AA /* OperationFeePolicy.swift */; };
+		0B817D8CE75D689CD87178C1 /* JSONDictionaryResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653FD23DE712676D0DFCA7D2 /* JSONDictionaryResponseAdapter.swift */; };
 		0B90CE79C85654F51E3D1E97 /* ConseilPlatformTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EF1D7D0F6C1FC15B1F0600 /* ConseilPlatformTest.swift */; };
-		0BCD32493E9F69FE1FE1E816 /* ForgingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F5486F9A024F623CF067A6 /* ForgingPolicy.swift */; };
+		0CD4F987EE82D3CEA1D6FD07 /* GetChainHeadRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FFC7595908A6BC3424370C /* GetChainHeadRPC.swift */; };
 		0D7D84AF58ACB013563EE162 /* ConseilClientIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1968AE0A3A2B4DAD756FD72 /* ConseilClientIntegrationTests.swift */; };
-		0DC3D9BE7F5F7FF916F9B24C /* Tez.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9B3CAED5792E4AB7750AF7 /* Tez.swift */; };
+		0E3E471E4B226BB3CF0C7493 /* FeeEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F58CAE6BB7F9A44407F558B /* FeeEstimator.swift */; };
 		0E894DABE68EC463E9C4E5D5 /* GetBigMapValueRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66310D79AAEC83514BB1F0F8 /* GetBigMapValueRPCTest.swift */; };
-		0F4C3ABE5D851C831AA4025D /* NetworkClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4F07ABD79921FDF2F0DF6A /* NetworkClient+Promises.swift */; };
+		0F732C98D081BB4791AEE2B0 /* IntMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC8C35C8541E0CBE377968D /* IntMichelsonParameter.swift */; };
 		0F880184124DF78BA42FEF54 /* TezosKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 632B9078CDB2B8EC754A858F /* TezosKit.framework */; };
 		0F9C94A2D1842106D3F7B6C7 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32F4925116A936510F4B1176 /* PromiseKit.framework */; };
-		0FFD5966D70D23B61C4BA7AB /* SignedOperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C148FC35AEA121D656379C4 /* SignedOperationPayload.swift */; };
 		1080A123F9F6DF86FE2840F5 /* NetworkClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CD7E1718D9928582CA4984 /* NetworkClientTest.swift */; };
-		112C531B1C24B1F194B9A97A /* GetExpectedQuorumRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30609498C728BF9A84131DD2 /* GetExpectedQuorumRPC.swift */; };
+		108B419FFDA7CF0729F362A8 /* TransactionOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84ECF4C95D1743641BEF321 /* TransactionOperation.swift */; };
+		123CA667757617121345656F /* ResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D9A0CB32FB707D9BF32654 /* ResponseAdapter.swift */; };
 		127F92545866411A37E2563A /* TezTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CF8E4119383EA36202FE25 /* TezTest.swift */; };
 		128311F2C5A0B70E2EE1D409 /* GetBallotsRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF9ECBC79C00C0B082798EB /* GetBallotsRPCTest.swift */; };
-		129605BCC7AC042FE0DED2C0 /* ConseilNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = B519E8A279DDEFD7B15D8A79 /* ConseilNetwork.swift */; };
-		1359AB823CB70E91CACC8182 /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04563738936938705E01305C /* Header.swift */; };
-		13BFF4B5ED4D326EC4948CE3 /* PeriodKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91787089B3FFEBEB100961FE /* PeriodKind.swift */; };
-		13C4F1C0EFE12E679B198B7C /* GetBallotsListRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F711CF77E0E756B9C7A707F /* GetBallotsListRPC.swift */; };
+		1283CBD6F35544031013F520 /* ConseilEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C935B8FA02AA0F4D639B200 /* ConseilEntity.swift */; };
 		142AB23ED4D91C70AF3695C1 /* OperationWithCounterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274E2A45E6EB2DCA9A6D1E3F /* OperationWithCounterTest.swift */; };
-		14FAE84BC3BFEBB6379D6A7E /* TezosNodeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 642373BEB9D3145F37EC1D68 /* TezosNodeClient.swift */; };
-		15E9CA64413A4EB306275585 /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2138A72B60E6669BDAE1DDEF /* Transaction.swift */; };
+		150BC04519380FB34ABE25AF /* OperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB59AEAEB019E7B641B448B1 /* OperationFactory.swift */; };
+		156B321DCC4509F69AFDFEEE /* OperationFeePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207E6BD1F08A190CAD16F7AA /* OperationFeePolicy.swift */; };
+		1625E43AF077065705ADBFFD /* GetProposalsListRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C714AAB4A35FE0C6B5BEB154 /* GetProposalsListRPC.swift */; };
+		17502DA144CE9470DAEB95AA /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E212CD2F0656857B66156D04 /* NetworkClient.swift */; };
 		17A22163503974F022A7BC47 /* TestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1D1F6B1DDF04EB174551D3 /* TestObjects.swift */; };
 		181ADCB55F2BE6E20455E914 /* GetBallotsListRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99377915F3FBFFD013D5DEA1 /* GetBallotsListRPCTest.swift */; };
+		182FFFF06C61C8B6624FFAF9 /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2344402EC93A8166B86CFAE /* Header.swift */; };
 		18BFCD6B7A5B59F7CD0E60E5 /* TezosCrypto.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D02267ED3BD3130460D19101 /* TezosCrypto.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		18EAEFA5541374412B3B4BA0 /* GetBallotsListRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F711CF77E0E756B9C7A707F /* GetBallotsListRPC.swift */; };
-		1977544AA681B3C2884EA342 /* TezosNodeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 642373BEB9D3145F37EC1D68 /* TezosNodeClient.swift */; };
+		19BF852742C7D35BD097808B /* GetBallotsListRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF606714D021D4EFFA07E6A /* GetBallotsListRPC.swift */; };
+		1A0E6F1CE869DB4A7C0D1C18 /* GetAddressDelegateRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06027E9BA1340E098E769026 /* GetAddressDelegateRPC.swift */; };
 		1A63200730FAA4748B49D99F /* SipHash.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B7186F1A7293750C49649CB /* SipHash.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1B9FB123314D857A238E4915 /* GetCurrentPeriodKindRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED831CC057088D0986D62D11 /* GetCurrentPeriodKindRPCTest.swift */; };
-		1CFE00B1E75656A8381551E8 /* ConseilQueryRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7020E9FBC44BF5513C0B1454 /* ConseilQueryRPC.swift */; };
-		1D27471CB576F7E0A858317E /* OperationMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DED6974896647B77A906EB /* OperationMetadata.swift */; };
-		1D64CE5FEE90429D1FA3FADE /* TransactionsResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6051D167763077DEB139912 /* TransactionsResponseAdapter.swift */; };
 		1DC5DA1117F29283567183C5 /* TezosKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4CC2EFE37BC672A082A9F69 /* TezosKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1E9C5855538818F3D00397AD /* GetContractStorageRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717CE63EDCDACE20EFDEF9A6 /* GetContractStorageRPCTest.swift */; };
 		1EB6AACD0B3AFA5E5A1F6662 /* RunOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A227FD388A5B50891D5C7FE1 /* RunOperationRPCTest.swift */; };
-		1EBB5724B144B638D36DE81F /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CD16AED7E1BA31C1679402 /* NetworkClient.swift */; };
+		1ED78FABDBE72F7DCB09474C /* DefaultFeeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66D157EC9056A7A23FBC45D /* DefaultFeeProvider.swift */; };
 		1ED82C2A01AAFD8F2431972F /* TransactionsResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2DD3668D2DD62AF8EDD738 /* TransactionsResponseAdapterTest.swift */; };
+		1F1BE8043A523F121852538E /* RPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A02A5F41589CD0850ED45F8 /* RPC.swift */; };
 		1F6DD057AE28085411DA52CC /* OperationPayloadFactoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFE3E8D18069FFC9F79BF11D /* OperationPayloadFactoryTest.swift */; };
-		22AA35D707876712CD2F8B7C /* GetProposalUnderEvaluationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBE32BE1DE6E1950D9B55EE8 /* GetProposalUnderEvaluationRPC.swift */; };
+		20C16CFCB554CF81CB2CF03C /* ForgingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2035C617A6D99FFB50ED1842 /* ForgingService.swift */; };
+		20E9FCE054F634DB3EBE0352 /* StringMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCF66588A24A65AA37CC90C /* StringMichelsonParameter.swift */; };
+		21DFB6D5F1C38A65473294A4 /* GetBallotsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84952454AD66BD8E378047D /* GetBallotsRPC.swift */; };
 		231A8423F33E60910EC2C9E7 /* TransactionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8230197EBFE429B4C99611 /* TransactionTest.swift */; };
+		232A22C322ECB499CE1ABB97 /* PreapplyOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B033280AD0AE71CF00F15555 /* PreapplyOperationRPC.swift */; };
 		23DB38D056F7E96126CCE218 /* TezosCrypto.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D02267ED3BD3130460D19101 /* TezosCrypto.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		242A7A44B6E8CBB749D1599A /* GetProposalsListRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37006AE33DD9117CB4E6FC9F /* GetProposalsListRPCTest.swift */; };
-		247C6E5E288037EBA00E77E9 /* GetReceivedTransactions.RPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA5396954524AB7F00F7087 /* GetReceivedTransactions.RPC.swift */; };
-		249C7B3773262E954704338D /* GetChainHeadHashRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32BF326F6AE9E5C4CA060A3E /* GetChainHeadHashRPC.swift */; };
-		2537CB1115383A24297244EF /* MichelsonComparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491C8771799EBFE1EEB5A40A /* MichelsonComparable.swift */; };
-		25410001FD50D214D5503CD0 /* GetAddressBalanceRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2482509F6BCADAE0E05A6F6B /* GetAddressBalanceRPC.swift */; };
-		255811A1BA8B43F6789C5293 /* UnitMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8720218B885AA9BD6720D237 /* UnitMichelsonParameter.swift */; };
-		2875D4D8D3B30CE41F76EA84 /* RPCResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1937A6487F44E50C4E03FEF5 /* RPCResponseHandler.swift */; };
-		289A83463CB9F040AB5FD071 /* BoolMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4FDF0314325E4EF8A1A6C2 /* BoolMichelsonParameter.swift */; };
-		28F2509DE289CE255EF909F1 /* OperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB03CEC43425522539E21D70 /* OperationPayload.swift */; };
+		246A505D04D6DD01AE3AE22F /* SimulationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BFF651BFE4E4A3E90313FA9 /* SimulationService.swift */; };
+		247E267F324622195781C7FC /* RightMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6400970C08C18B3CAD121530 /* RightMichelsonParameter.swift */; };
+		252A8D548EB7E2581096E4AF /* OperationMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4BE9708692F1E9BEFA4B1DA /* OperationMetadata.swift */; };
+		262E887F091430DD45BB3D37 /* NoneMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588112F5BDBF5213EB952EF1 /* NoneMichelsonParameter.swift */; };
+		2655ECC6A0A89FDF23DF18A6 /* GetAddressCounterRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF147FA8F9FDDEBA70FA2759 /* GetAddressCounterRPC.swift */; };
+		26684AB4366572B8B2CD89D5 /* GetAddressManagerKeyRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B01627EE910CBE5821502281 /* GetAddressManagerKeyRPC.swift */; };
+		2699AF538FEBA53B91818459 /* GetChainHeadRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FFC7595908A6BC3424370C /* GetChainHeadRPC.swift */; };
+		26BD1B449C1BDF0A34EB3424 /* ConseilQueryRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF24BCDA4254C7A2D50F5728 /* ConseilQueryRPC.swift */; };
+		27641CCD3D8C9AC9A6719869 /* PeriodKindResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B64C2C9B1E8CA1987CC98B /* PeriodKindResponseAdapter.swift */; };
 		295CD232F78E4BF22DF07836 /* GetExpectedQuorumRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68B50E6C20187E9AC1CDB8E /* GetExpectedQuorumRPCTest.swift */; };
-		2AF6668B3DC57C241E92534F /* FeeEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D2867D9C408D2B95898ADA /* FeeEstimator.swift */; };
+		29E4A4AC683B33EFF8D6E0AE /* SimulationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6736E66F6C33A71E96D8AA57 /* SimulationResult.swift */; };
+		2B6489B6FC91E02E2474922C /* UnitMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D650111C52C89A65467CC889 /* UnitMichelsonParameter.swift */; };
 		2BC5814E801A9DE73F1005E3 /* GetProposalUnderEvaluationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A43F54FBE7049C2AAE4183 /* GetProposalUnderEvaluationRPCTest.swift */; };
-		2CEA5ABD962A5EF2932B7602 /* InjectOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FFA7CD21B5166D4B00FE81 /* InjectOperationRPC.swift */; };
-		2D05A19038C29F31FC2A7B2A /* MichelsonAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DFE5FA302C7A796117730E /* MichelsonAnnotation.swift */; };
 		2D0CE54716647A1E451F4656 /* BigInt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95F395F6CD3F62BF5D3FCED1 /* BigInt.framework */; };
 		2D6C0C315D17B5E0276397CD /* TokenContractIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99F7EF575AEA6BE191F2001 /* TokenContractIntegrationTests.swift */; };
-		2DA7B278C4503B28F95D49C5 /* GetChainHeadRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35391E8EF3DDA108123FA448 /* GetChainHeadRPC.swift */; };
-		2EC3069A36FD23F3F32DC012 /* BytesMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AEFED21F731CED4DC60270 /* BytesMichelsonParameter.swift */; };
+		2EA1145A13E79EA9F466EE0B /* Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4387729ED2573C33E3320F /* Wallet.swift */; };
 		2EEA0C43AC16E0F763D99135 /* SipHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B7186F1A7293750C49649CB /* SipHash.framework */; };
-		2FC3AF915DDA64D799EEDFBA /* AbstractMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8D4BAA248CCB8092FBF3B3 /* AbstractMichelsonParameter.swift */; };
 		3038187975E341D0F6873E83 /* GetProposalsListRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37006AE33DD9117CB4E6FC9F /* GetProposalsListRPCTest.swift */; };
-		307771AC3EEB8B3EC9B6FB9F /* GetBigMapValueRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04749A677766E0B141A86229 /* GetBigMapValueRPC.swift */; };
-		30DB919CF9D288E7FC110786 /* ConseilEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D05B324BA34CBCC7042F74 /* ConseilEntity.swift */; };
-		314DC0220D09F33267BF262E /* SimulationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE36695F3C93A5DB12218A6E /* SimulationService.swift */; };
 		31D8798EC390CCE0AAA952AC /* Sodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCD4318870B3E4FE3F27C60D /* Sodium.framework */; };
 		32144B5BCBA06B8114DF0F0D /* TezosNodeClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A480E400F3C3D065639376F4 /* TezosNodeClientTests.swift */; };
 		323631CC9EF11EB971525EA6 /* Base58Swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A7284743A69C9A12186E4D67 /* Base58Swift.framework */; };
 		3255CEC47E34C92CFAD279ED /* SipHash.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 737132D7F972BD110818F565 /* SipHash.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		32808CF2255B6C966753FC38 /* InjectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D2924E8F0BF0C9EA55CF17B /* InjectionService.swift */; };
-		33538282B4A0BEE7608532CB /* GetAddressDelegateRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 381654F03DF6614286E0CA1D /* GetAddressDelegateRPC.swift */; };
 		344530B289ACAD25404E5452 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B3BE4BAECB893457A44FC1 /* TestHelpers.swift */; };
 		34473DC68AF5DC541FC41AD8 /* SipHash.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 737132D7F972BD110818F565 /* SipHash.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		346B3C1348BED784D82EF921 /* OperationWithCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04781056C289A009489C072C /* OperationWithCounter.swift */; };
 		34E43B75D92CE9FE2726F960 /* ConseilClientIntegrationTests+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B2484FD06C8D95BB5ACDCC /* ConseilClientIntegrationTests+Promises.swift */; };
-		350917ED569642CFB0290705 /* ForgingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401294647448C99634146C3B /* ForgingService.swift */; };
 		3591C65A03D45513CC06B457 /* AbstractOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5FAF254AF66B1A805ABF27 /* AbstractOperationTest.swift */; };
-		37000C76751363703B9438BB /* SignedOperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C148FC35AEA121D656379C4 /* SignedOperationPayload.swift */; };
-		3731170B8898FF878EB37A61 /* SigningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E00624B1C53DDE6AF8A9C2 /* SigningService.swift */; };
+		3698330EA50903CD0AEEC185 /* Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6067C4058BC42C52B64AF93A /* Hex.swift */; };
+		369AFABBC4DC7B34F4122FE7 /* GetAddressCounterRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF147FA8F9FDDEBA70FA2759 /* GetAddressCounterRPC.swift */; };
 		381DBFEA8AB85D0A93AD40FE /* TestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1D1F6B1DDF04EB174551D3 /* TestObjects.swift */; };
-		387EDFCFEC4190BB903B916D /* TezosProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DF562D0F0EB275D1CDF473 /* TezosProtocol.swift */; };
-		396065508F2B015FEB61A4FC /* DefaultFeeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2448ECF9B1DEED57061162E8 /* DefaultFeeProvider.swift */; };
-		3B606277954B7E779A8F4640 /* DelegationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E694BC28D2B08EEF39AAB889 /* DelegationOperation.swift */; };
-		3BE23B5036B78060364F4C23 /* TransactionsResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6051D167763077DEB139912 /* TransactionsResponseAdapter.swift */; };
+		3837CAC485DCEEA626A0602E /* PreapplicationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74BC96BBBBF950226E07E85 /* PreapplicationService.swift */; };
 		3C99F5A58A32231BE0820A4A /* GetBallotsRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF9ECBC79C00C0B082798EB /* GetBallotsRPCTest.swift */; };
 		3CC9387F30A2C0880378097A /* TezosKitErrorCodesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4254B915770CD924FBBE9D /* TezosKitErrorCodesTest.swift */; };
-		3D46A73EE4F6CC255795FA65 /* PeriodKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91787089B3FFEBEB100961FE /* PeriodKind.swift */; };
+		3D0DFC6B5FED520A51FFA5ED /* SigningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1E035A6252AD79E6A4AAD1 /* SigningService.swift */; };
 		3DD35013DA97BA70B30E7ADF /* MnemonicKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD4B1012288DD6F90E8C78A /* MnemonicKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		3E5182800DAD57ABCD180966 /* RevealOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B028588E2CA02E910DA28DA /* RevealOperation.swift */; };
 		3E56D8D9630D6F609A7888B1 /* ConseilEntityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA46CF630A8512DF758EB2E2 /* ConseilEntityTest.swift */; };
+		3F3B6E81340BD7ECFCE8FBAF /* ForgeOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF8AE07E00BB723F1C5F139 /* ForgeOperationRPC.swift */; };
+		3F5EE99A632A748BBB6D0FE4 /* IntegerResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109F98709DCC0A5351158718 /* IntegerResponseAdapter.swift */; };
 		3FA01EA6B1FC4327269B16A9 /* PromiseKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 32F4925116A936510F4B1176 /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		402422891004DF57E8B73278 /* NoneMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE87395F6EA86F5E466AFBB /* NoneMichelsonParameter.swift */; };
-		4074E55E8D9F1A537FC937C5 /* TransactionOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522E98DE7193F42BCB3CF361 /* TransactionOperation.swift */; };
+		40708A0C7052EF4251CD9BAC /* GetSentTransactionsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1564F45DEFBC0D755FAB0218 /* GetSentTransactionsRPC.swift */; };
 		40ACC605362177DDD753AF43 /* CodingUtilTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47259C26A53DB562B22F087B /* CodingUtilTest.swift */; };
 		40D3B5BF40C5EE325C951BB2 /* FeeEstimatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC56B6DF6FF924206963D52 /* FeeEstimatorTest.swift */; };
 		41806A8A36A64F5A02A7516D /* Base58Swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F47131DE435D053FC8DE2DBF /* Base58Swift.framework */; };
@@ -121,300 +108,313 @@
 		42C6EC2C5F1116F51E418346 /* Sodium.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BCD4318870B3E4FE3F27C60D /* Sodium.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4350DC1C7DBE24A5CD98AA7B /* InjectOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4090B8A708287039DE6178F4 /* InjectOperationRPCTest.swift */; };
 		436B5261EE50B89522E48D7E /* DexterExchangeClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD41CEB7ECEE9702B9C8B24 /* DexterExchangeClientTests.swift */; };
-		437BF161917064D43BAE2EC5 /* DefaultFeeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2448ECF9B1DEED57061162E8 /* DefaultFeeProvider.swift */; };
 		43E7ACC7E751DB461975BF40 /* FeeEstimatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC56B6DF6FF924206963D52 /* FeeEstimatorTest.swift */; };
 		44C3965BA3A4826A0D353733 /* GetExpectedQuorumRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68B50E6C20187E9AC1CDB8E /* GetExpectedQuorumRPCTest.swift */; };
-		45172B4BB09294806142D0B3 /* GetVotingDelegateRightsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6E931C81E3260C22CF2F78 /* GetVotingDelegateRightsRPC.swift */; };
 		454C53CFDFEDE21EC414A2E2 /* GetContractStorageRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717CE63EDCDACE20EFDEF9A6 /* GetContractStorageRPCTest.swift */; };
-		461CAA4EB8501EA579D7205E /* GetReceivedTransactions.RPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA5396954524AB7F00F7087 /* GetReceivedTransactions.RPC.swift */; };
+		45FF7FCB7F2351BA549C6BDF /* AbstractOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BC48461432501639D06FD6 /* AbstractOperation.swift */; };
+		4810379C933F3041C8193B3E /* TezResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF068374D26E5AD6CE93407 /* TezResponseAdapter.swift */; };
+		491266272393A7957B05EC64 /* RPCResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D884FB468334AB4A1BB1C6A /* RPCResponseHandler.swift */; };
 		4914D80B62C56254DE5FBAC5 /* CodingUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2415E6BE21BBCACF5128B13 /* CodingUtil.swift */; };
 		4B6C324D7B7F0D168A2AC30B /* SimulationServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B48169F083D2DAEB462840 /* SimulationServiceTest.swift */; };
-		4B9A89D609ED62D5386EEE76 /* GetContractStorageRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5DEBE164AA357B20FDE72D /* GetContractStorageRPC.swift */; };
 		4BD62C82867F43FEABF42D9E /* GetAddressCounterRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C525A21D32496E9B7BB4F79A /* GetAddressCounterRPCTest.swift */; };
 		4C5067BBCFC33C126105C66D /* JSONDictionaryResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3F1D59FA8A152B8A66043A /* JSONDictionaryResponseAdapterTest.swift */; };
 		4CFF0C9367C70838D3C7E88A /* CodingUtilTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47259C26A53DB562B22F087B /* CodingUtilTest.swift */; };
-		4D43A79A774C271765314A72 /* OperationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6B134F7A1B3563395024FC /* OperationKind.swift */; };
 		4D5203CB5AE5F88C2F55ABF7 /* CodingUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2415E6BE21BBCACF5128B13 /* CodingUtil.swift */; };
-		4E8E479655D27E3D722C68C3 /* ConseilClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188ACB3031C05C0613EF388D /* ConseilClient+Promises.swift */; };
+		4DA4C7C8FA36B8D9C7739E5A /* SomeMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB80D50511873CF9783361B4 /* SomeMichelsonParameter.swift */; };
+		4EE95B692BE0F6AFF3B9AE13 /* TezosKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754389C145F7AF7208CBBD41 /* TezosKitError.swift */; };
+		4F0AC7852283D8C563FBAA9A /* OperationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81337F4A5B2C502DB3D076 /* OperationKind.swift */; };
+		4F2F78B301A1CE1C55EE77BA /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6AA3CAB521F463866CFB96 /* TezosNodeClient+Promises.swift */; };
+		4FCF97E349053D21AE8E506E /* GetProposalUnderEvaluationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407B756EB7320CC968E1C2ED /* GetProposalUnderEvaluationRPC.swift */; };
 		507040285C936250D661F395 /* BigInt.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95F395F6CD3F62BF5D3FCED1 /* BigInt.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		50D2C68AA4145527E3333F6F /* StringResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B474664A9C0C8EA93EA08 /* StringResponseAdapterTest.swift */; };
 		50D5AF8F52F0363F90F9EF6D /* GetDelegateRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA474C90E513C4377433A85C /* GetDelegateRPCTest.swift */; };
+		51019358C9044908CD8DAA42 /* BoolMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04B3A5C6B64BB78285FD5F6 /* BoolMichelsonParameter.swift */; };
 		5104508D0317778C144DC50B /* ConseilClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3615893425C81BD4E9E677D /* ConseilClient.swift */; };
 		511F64E3E072BCC48A75B104 /* ConseilNetworkTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AB3DCEF101AC8B5CB3BEBD /* ConseilNetworkTest.swift */; };
 		5138EF22727F2F743CAFABFB /* TokenContractClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A10B24E2BC78C098FCC8042 /* TokenContractClientTests.swift */; };
-		51A35E3DEFAAF1383850AFC1 /* GetCurrentPeriodKindRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A083D21A561E16A7E8267BB8 /* GetCurrentPeriodKindRPC.swift */; };
-		5287C9940539CF378C1BBDB8 /* JSONDictionaryResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03192BD63A21CFBD8D392FAF /* JSONDictionaryResponseAdapter.swift */; };
-		530D2848C9DDDAFCF350311F /* GetCurrentPeriodKindRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A083D21A561E16A7E8267BB8 /* GetCurrentPeriodKindRPC.swift */; };
+		5176340FF8C190A4F793CDBB /* RunOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC51B27A148DD74109FEB276 /* RunOperationRPC.swift */; };
+		528E6A128E816E8527C341C8 /* GetCurrentPeriodKindRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933679D90DA718BAE1ECF1ED /* GetCurrentPeriodKindRPC.swift */; };
 		5315F49C61534B939678E39C /* JSONUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17556CA46001F8FB5DF8302 /* JSONUtils.swift */; };
 		533A5053F740E77A3B4C8D49 /* TezosCrypto.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 39FE75C2C5F5177A3F3C6752 /* TezosCrypto.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5389CCFD5B56EE25875F0831 /* GetAddressBalanceRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1D2B885A5A1D1477E020C5 /* GetAddressBalanceRPCTest.swift */; };
 		551B28DEADF45160381A1AD1 /* SignedProtocolOperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BA885B9E3E1F6BA3693A3F /* SignedProtocolOperationPayload.swift */; };
 		553FF969BB533739E58C5A29 /* TezosNodeIntegrationTests+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900000AC3F1E51ABDB97459A /* TezosNodeIntegrationTests+Promises.swift */; };
-		557704861BEEC380E6EE45B4 /* OperationFees.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9A9185EB72DCD21724F958 /* OperationFees.swift */; };
-		58069C1F41C671CAAA8A1517 /* GetChainHeadRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35391E8EF3DDA108123FA448 /* GetChainHeadRPC.swift */; };
+		565974251F53ED2304F67976 /* GetAddressManagerKeyRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B01627EE910CBE5821502281 /* GetAddressManagerKeyRPC.swift */; };
+		56AE01634FDD6F3CC966BCEF /* InjectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361D83203112185AC915DDD2 /* InjectionService.swift */; };
+		5762636B9F6E606FCF4E6981 /* MichelsonAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F15CD865BE921BF9DF8CC0 /* MichelsonAnnotation.swift */; };
+		5784F09DB5EC30B20CA0F97C /* GetVotingDelegateRightsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBD6A96F194F57F5A9AE2DA /* GetVotingDelegateRightsRPC.swift */; };
 		5887D02AA393101D925EFE47 /* FakeObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4465D045474BB982821D86 /* FakeObjects.swift */; };
-		5963AA62543B2A7B5240E692 /* ConseilQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D552948C9850FA50ED7155 /* ConseilQuery.swift */; };
-		598E95267D758C5779D41C2C /* SignedProtocolOperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3A9E501C57BFCAACBE8097 /* SignedProtocolOperationPayload.swift */; };
-		599101D7C07D1947A453A96E /* GetAddressCounterRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077C78A023A80EBCC499DCDA /* GetAddressCounterRPC.swift */; };
+		5921B5ED76C2A0C0C67E36DA /* TezosNodeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A82D9C70BEC192B4D73809 /* TezosNodeClient.swift */; };
 		59A2F834737A398C874C200B /* TezosNodeClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A480E400F3C3D065639376F4 /* TezosNodeClientTests.swift */; };
+		59F27929724F9EF92946A3FC /* GetOriginatedContractsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7008A9105E3151B6B23496F1 /* GetOriginatedContractsRPC.swift */; };
 		5AAA401A5BDA0FDE53C38EBC /* WalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1596A9E29DF24E63C454D2DD /* WalletTests.swift */; };
 		5B9C772D561E314CE6957CBD /* GetChainHeadRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4252DFDE63B35970A3B59A /* GetChainHeadRPCTest.swift */; };
-		5BEF10AACEE0CD411D694597 /* GetAddressManagerKeyRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A0F3B28B28D6070679E253 /* GetAddressManagerKeyRPC.swift */; };
-		5C38482F3CF82120DFC54025 /* PreapplicationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0D3BC47F4385A7FC52AD88 /* PreapplicationService.swift */; };
+		5C243C48B85DBB99E58CE34C /* AbstractResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29024177105AD82662279805 /* AbstractResponseAdapter.swift */; };
+		5C9E6119D5B8F50A8C076024 /* GasLimitPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F867E1CE5F1920E101259B /* GasLimitPolicy.swift */; };
 		5CEAF373227D96DD66C2E95E /* InjectionServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443F94AEAF2C38E5B751E7EC /* InjectionServiceTest.swift */; };
-		5EB5EA8B955EA5BE0F4B2F4A /* RPCResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1937A6487F44E50C4E03FEF5 /* RPCResponseHandler.swift */; };
+		5F860D6BBCAFFF96C507623B /* Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6067C4058BC42C52B64AF93A /* Hex.swift */; };
 		603E6A402CDCC7CBD6F24BC4 /* PreapplyOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC385B9CD31989369391F0B6 /* PreapplyOperationRPCTest.swift */; };
-		61458E0CABF9E7287F7EB451 /* NoneMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EE87395F6EA86F5E466AFBB /* NoneMichelsonParameter.swift */; };
-		61802B4AD8A464BAC5E9237E /* TezResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D18AF3E00B8343E3EA6793B /* TezResponseAdapter.swift */; };
+		609CBA9E58941C450A963639 /* MichelsonComparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525C931C7CD120487B51DA9A /* MichelsonComparable.swift */; };
+		619E6BD3481626F8DA9E6FA2 /* PeriodKindResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B64C2C9B1E8CA1987CC98B /* PeriodKindResponseAdapter.swift */; };
 		62903921C8ECC8722A4C546D /* MichelsonAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362C94B98BAA147AB9D080DC /* MichelsonAnnotationTests.swift */; };
 		62A5879D7602B510810B924D /* OperationWithCounterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274E2A45E6EB2DCA9A6D1E3F /* OperationWithCounterTest.swift */; };
 		62C0718A0A00329A5232FF3A /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AFC77643CD2C374042E0B932 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		630E1EDFD10D8C4D026295A6 /* SimulationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A61A9EA0FA8878B570608F2 /* SimulationResult.swift */; };
 		64185B7D0E39391674A70F5A /* OperationPayloadFactoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFE3E8D18069FFC9F79BF11D /* OperationPayloadFactoryTest.swift */; };
 		649E1CC62E843A2E2282421F /* NetworkClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CD7E1718D9928582CA4984 /* NetworkClientTest.swift */; };
+		64F80C86597E217AD2DEC700 /* ConseilClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0922D1ADC86CC9907C3EEBA2 /* ConseilClient+Promises.swift */; };
 		661D5439AA293CB6889B44D0 /* PreapplicationServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FCF6EFDB51394D49E1479C /* PreapplicationServiceTest.swift */; };
-		67DA3118B1A853A9F81DABE8 /* MichelsonComparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491C8771799EBFE1EEB5A40A /* MichelsonComparable.swift */; };
 		67DB95698039F1F5066DCE16 /* OperationMetadataProviderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67BF17864BD54D09DB6CE2FA /* OperationMetadataProviderTest.swift */; };
 		685B8D04ABE7F1B2CC0152B9 /* Sodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F588414A4E9819AFC69197D /* Sodium.framework */; };
 		68EDC5143C1520CBEFB527EA /* SignedOperationPayloadTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A461E89A11A327962A4232 /* SignedOperationPayloadTest.swift */; };
-		6974FC94889C888118071F40 /* InjectOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FFA7CD21B5166D4B00FE81 /* InjectOperationRPC.swift */; };
-		69A55F43BE2B14F6B5215FC6 /* OperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72ABB0C779885F2546CA5D72 /* OperationFactory.swift */; };
-		6A47C111B524E972AFB13429 /* GetBallotsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0D366C40486A00374DF8CE /* GetBallotsRPC.swift */; };
+		68EE902B48CF6D7D19AC7E67 /* ForgingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2035C617A6D99FFB50ED1842 /* ForgingService.swift */; };
+		69D1108BBFEF81261566FF65 /* GetBallotsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84952454AD66BD8E378047D /* GetBallotsRPC.swift */; };
+		6A010379E6D6E1574A25E439 /* SigningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1E035A6252AD79E6A4AAD1 /* SigningService.swift */; };
 		6AC4FC819BE657D545D58D65 /* TokenContractClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8CAB1EBF88156948D30F4 /* TokenContractClient.swift */; };
-		6B2235B0F121E7BF9D10F839 /* GasLimitPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0FF13E4D9C5918D8D37D91D /* GasLimitPolicy.swift */; };
-		6CF256A926954581A0CE454A /* StringResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB37423CE931B84272136EE6 /* StringResponseAdapter.swift */; };
+		6ADF54D797E8287A5DD92EC5 /* OperationMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A057E76CA636DDEE045ED59C /* OperationMetadataProvider.swift */; };
+		6C211B5899F3AB595386C678 /* JSONDictionaryResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653FD23DE712676D0DFCA7D2 /* JSONDictionaryResponseAdapter.swift */; };
+		6D8731CE158D6378887B5A33 /* ConseilClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0922D1ADC86CC9907C3EEBA2 /* ConseilClient+Promises.swift */; };
+		6D91DBD85F5F525826CC55FE /* GetContractStorageRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C07BA2584C54711181C33DE /* GetContractStorageRPC.swift */; };
 		6DD065FF295ADBB604B88EF1 /* PromiseKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 32F4925116A936510F4B1176 /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6DD1697EEE7C52FC8DEF9C56 /* BigInt.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7806BE5035AB3100BA7C791C /* BigInt.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6EA2C05ED0589F4D707AA291 /* TestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1D1F6B1DDF04EB174551D3 /* TestObjects.swift */; };
 		6F0897EA9573CAB639F02CF3 /* SipHash.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 737132D7F972BD110818F565 /* SipHash.framework */; };
-		6F406259A8C7EA4959D7A21A /* RunOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25142F4DE87022CF0EDD8C9 /* RunOperationRPC.swift */; };
-		6FF51F7D08A6841414E9979D /* AbstractResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8057B4D69396C9B0D6C3476D /* AbstractResponseAdapter.swift */; };
-		71B9042ABE47B85C295BF8DF /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B73FFA1626222EBAE4742B /* Operation.swift */; };
+		70CA92EE6BB35E2898853956 /* OperationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81337F4A5B2C502DB3D076 /* OperationKind.swift */; };
 		71CDB3CEDB0DDBF567B6EDE8 /* NetworkClientTest+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DF61B717DBD0486D2AADF2 /* NetworkClientTest+Promises.swift */; };
+		71E5791297A5DAE0D0D5C9C6 /* TransactionsResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A00D85C90C2E12DDC02E709 /* TransactionsResponseAdapter.swift */; };
 		727FAAC57D3B5FB1DFC993F6 /* ForgeOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3C6101EC3A6572348C068C /* ForgeOperationRPCTest.swift */; };
-		75239C4752AB9BD7F7876662 /* RightMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B964675925220276FC8DAD2C /* RightMichelsonParameter.swift */; };
+		72E412B5F9680EE29264A648 /* PublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C67169ED922069E2D7A0A5 /* PublicKey.swift */; };
+		730FC94BF17634F7B0A065C0 /* GetCurrentPeriodKindRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933679D90DA718BAE1ECF1ED /* GetCurrentPeriodKindRPC.swift */; };
+		74702CAD5E79A2B0DA1D3494 /* JSONArrayResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039C325259AE4DD3416B4F30 /* JSONArrayResponseAdapter.swift */; };
+		767808D0C01FF2CB4F56C5CC /* PeriodKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FEF269B74ED2BB4A9C9FB8 /* PeriodKind.swift */; };
+		768EC7127649F743CADF5485 /* InjectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 361D83203112185AC915DDD2 /* InjectionService.swift */; };
+		76E015C816A9797BEA99C3D1 /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E212CD2F0656857B66156D04 /* NetworkClient.swift */; };
 		76FDABA9BB58D85B61F56E87 /* SignedOperationPayloadTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01A461E89A11A327962A4232 /* SignedOperationPayloadTest.swift */; };
-		775151EF78905D8F766556FB /* GetOriginatedContractsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A34A9046970ADD98F3AEFA4 /* GetOriginatedContractsRPC.swift */; };
-		79E4E7544E310FE65CF96934 /* GetAddressCounterRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077C78A023A80EBCC499DCDA /* GetAddressCounterRPC.swift */; };
-		7AD56823491D043EA4175D1E /* Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD53D15FDED0B9265AC96E1 /* Hex.swift */; };
+		775E7DBBE39DCB0644DF5E42 /* UnitMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D650111C52C89A65467CC889 /* UnitMichelsonParameter.swift */; };
+		77A465AF8459D646E26EDDF4 /* GetContractStorageRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C07BA2584C54711181C33DE /* GetContractStorageRPC.swift */; };
+		77CF4AAA059852274EECC261 /* GetSentTransactionsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1564F45DEFBC0D755FAB0218 /* GetSentTransactionsRPC.swift */; };
+		7AC9104107B7C65E0157CDAA /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53D59AD9EA44F6B351A350F /* Transaction.swift */; };
 		7ADA70F21D418E673B3D1FC2 /* TezosCrypto.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 39FE75C2C5F5177A3F3C6752 /* TezosCrypto.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		7CAD6087AFD81CC0FB00ACDE /* Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB11A435CDBF5E17784FD6BB /* Wallet.swift */; };
+		7B0AFC2B03A527B407CD802C /* MichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908CE3F01F463AD656302DFD /* MichelsonParameter.swift */; };
+		7D7DE0D66FA04949CD3EBF56 /* MichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908CE3F01F463AD656302DFD /* MichelsonParameter.swift */; };
 		7DBDD4E5B7E0D5672BDDA73E /* MnemonicKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD4B1012288DD6F90E8C78A /* MnemonicKit.framework */; };
-		7E2938740F4A7E993A9C048E /* TransactionOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522E98DE7193F42BCB3CF361 /* TransactionOperation.swift */; };
-		7E5F52B8661857E80054650D /* PairMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE985D5D40374131C51C3D3 /* PairMichelsonParameter.swift */; };
+		7E28672FA338FA3D8E163026 /* ConseilQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB45514356C89019DB00E50 /* ConseilQuery.swift */; };
+		7E5A3D04C2B733F09D4922D6 /* GetAddressDelegateRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06027E9BA1340E098E769026 /* GetAddressDelegateRPC.swift */; };
 		7E6E373291B11AA50DAF5E23 /* SignedProtocolOperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BA885B9E3E1F6BA3693A3F /* SignedProtocolOperationPayload.swift */; };
 		7E9E2DB534512C446CBA1398 /* ConseilClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BCD5416B3E149D9389F6961 /* ConseilClientTests.swift */; };
 		7ED3161165E0FEEC89484C6E /* GetVotingDelegateRightsRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39091129CFF302C9A24A91C3 /* GetVotingDelegateRightsRPCTest.swift */; };
 		7F343BFAB58B2CF79A43C7F3 /* BigInt.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95F395F6CD3F62BF5D3FCED1 /* BigInt.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7FD0E60380F87B63E1CD2A8F /* TokenContractIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99F7EF575AEA6BE191F2001 /* TokenContractIntegrationTests.swift */; };
 		7FDA5BA76816673900126CB3 /* MnemonicUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3D7B0277CE3BF6560DFD91 /* MnemonicUtilsTest.swift */; };
-		8165DE8F772C1AE0A7E66BC3 /* OperationPayloadFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2B5D0CAE285FAC9FE43EE3 /* OperationPayloadFactory.swift */; };
+		81E9D372DFF93EDC78B4A69A /* GetReceivedTransactions.RPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0675B789B9F5EF98BC4E4568 /* GetReceivedTransactions.RPC.swift */; };
 		826CAAB671AEE759E1F7A80A /* SigningServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DD030C2ACB7856608B34BA /* SigningServiceTests.swift */; };
-		82705C677A1705DE861B5837 /* Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD53D15FDED0B9265AC96E1 /* Hex.swift */; };
-		8308A1E55F8BAD7EF8DDD13C /* ConseilQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D552948C9850FA50ED7155 /* ConseilQuery.swift */; };
+		83A3CE6EDD434DE0657A3E39 /* GasLimitPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F867E1CE5F1920E101259B /* GasLimitPolicy.swift */; };
+		84835281C8BB752513193EC6 /* PairMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7B9AE14DF5799CA2EEFDCD9 /* PairMichelsonParameter.swift */; };
 		84D5C538E429370571F6B022 /* RunOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A227FD388A5B50891D5C7FE1 /* RunOperationRPCTest.swift */; };
 		85026F71DEB4414B03D92624 /* PreapplicationServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FCF6EFDB51394D49E1479C /* PreapplicationServiceTest.swift */; };
-		850FA2C5B3942A9E976BFBB7 /* OperationWithCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E537FD113A64E725641F52 /* OperationWithCounter.swift */; };
+		858F078119CB4C2CD735E34D /* TezosProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B059E31F2A63807B325D4115 /* TezosProtocol.swift */; };
+		85BC63DB233D9E4663D05D6B /* OperationPayloadFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE0279DC6099EED8F2D4CF9 /* OperationPayloadFactory.swift */; };
 		8631A783EBB8BA07F24BD8D6 /* TestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1D1F6B1DDF04EB174551D3 /* TestObjects.swift */; };
-		8648DF0DE1A1F5B78171CB3B /* ResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD98E74C85F222A0944B8EC /* ResponseAdapter.swift */; };
-		871C12C4F112AEE8E7D21F44 /* LeftMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C8ED8DF8D7C503E41656D3 /* LeftMichelsonParameter.swift */; };
+		86A23698EB0F1A7C654EA5FE /* TezosNodeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A82D9C70BEC192B4D73809 /* TezosNodeClient.swift */; };
 		871FE402420222A66F323F7B /* MichelsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2ED9478409396EF8CA5E053 /* MichelsonTests.swift */; };
+		8756D5F4B281D22404F1A645 /* GetExpectedQuorumRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E006B0AA63CD2D50D07762F /* GetExpectedQuorumRPC.swift */; };
+		88940D2D624897654210349C /* GetProposalsListRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C714AAB4A35FE0C6B5BEB154 /* GetProposalsListRPC.swift */; };
+		892E99DE1CF34B1762EF4EF1 /* Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4387729ED2573C33E3320F /* Wallet.swift */; };
 		89385B570B73F859DD132068 /* MnemonicKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 61EDBE7577517E6ACF2498A2 /* MnemonicKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A33807BC7E3F132F72A4F8E /* NetworkClientTest+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DF61B717DBD0486D2AADF2 /* NetworkClientTest+Promises.swift */; };
-		8C9B2596C4F5C9A80B42F1CA /* OperationFeePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC90AB66610CCED41A30ED13 /* OperationFeePolicy.swift */; };
-		8CEEEE67BD78AE6796BB1B40 /* GetAddressDelegateRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 381654F03DF6614286E0CA1D /* GetAddressDelegateRPC.swift */; };
+		8A8A0C3FA8BB4D7D06B3BC41 /* Tez.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6EF4B87FBEBB73B166F339 /* Tez.swift */; };
+		8AA7945D4413BEEE0DD45E38 /* DelegationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170AD904F169111FBCD93FCC /* DelegationOperation.swift */; };
+		8ADF28B51303B381B5BADF71 /* ResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90D9A0CB32FB707D9BF32654 /* ResponseAdapter.swift */; };
+		8B2EA0D1375841337C15C2E1 /* ConseilQueryRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF24BCDA4254C7A2D50F5728 /* ConseilQueryRPC.swift */; };
+		8B8CA3EF54C673DA42012EA7 /* NoneMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588112F5BDBF5213EB952EF1 /* NoneMichelsonParameter.swift */; };
+		8BE28CF8A5B3B2FD3C2D3781 /* SignedProtocolOperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2FD2E17433D630AA933B5B /* SignedProtocolOperationPayload.swift */; };
 		8CF091BDFB42E3D5E901AFE7 /* PeriodKindResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33048AAA1D1966A1A89E409F /* PeriodKindResponseAdapterTest.swift */; };
+		8DB6E3EE6F04C2FF16A37338 /* MichelsonComparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525C931C7CD120487B51DA9A /* MichelsonComparable.swift */; };
 		8DCB9187C5EBB48176D3220B /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B3BE4BAECB893457A44FC1 /* TestHelpers.swift */; };
 		8E1B831D9057353CADC4593B /* TezosKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 632B9078CDB2B8EC754A858F /* TezosKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		8E9911DADF5C9528BB5D46BE /* Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB11A435CDBF5E17784FD6BB /* Wallet.swift */; };
-		8EC21214B05CBFE1740BC608 /* TezResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D18AF3E00B8343E3EA6793B /* TezResponseAdapter.swift */; };
+		8F5F5CAA8F8726A3391FB576 /* SignedOperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A700A211C7AB1E92C5D7C3F4 /* SignedOperationPayload.swift */; };
 		8FECE292B57AFEF74215AD0C /* ForgingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A2247E719CDA0FA064FBD3 /* ForgingServiceTests.swift */; };
 		903EB67CD037E70E5C05E7F5 /* JSONUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9983FD251855D94BAF486306 /* JSONUtilsTest.swift */; };
+		903F786504865D80F76138B1 /* AbstractMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8A19E59C8D7BEEA9368BE4 /* AbstractMichelsonParameter.swift */; };
 		90C287D2286F418919E0CB17 /* JSONArrayResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C842EEAE2CDE5CE4F0C326 /* JSONArrayResponseAdapterTest.swift */; };
 		91A310B7A87C5B736F4F8F3D /* SimulationServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B48169F083D2DAEB462840 /* SimulationServiceTest.swift */; };
+		91A50FD1A526067E9A12F919 /* OperationMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4BE9708692F1E9BEFA4B1DA /* OperationMetadata.swift */; };
 		91F7DB335A6358E36BD62134 /* FakeObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4465D045474BB982821D86 /* FakeObjects.swift */; };
-		93C8369FD5BAECF82E3CA67B /* PublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F295C6AC52D42CE43FB618F /* PublicKey.swift */; };
+		92813B3FAE81849626114B08 /* MichelsonAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F15CD865BE921BF9DF8CC0 /* MichelsonAnnotation.swift */; };
+		933B932FCB6435B861C30DE7 /* GetOriginatedAccountsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66957E41DB2A3F6E370C7964 /* GetOriginatedAccountsRPC.swift */; };
 		94C7392EDEF6750F9B766A89 /* PreapplyOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC385B9CD31989369391F0B6 /* PreapplyOperationRPCTest.swift */; };
-		94D159D68D4A6283663F95A1 /* PeriodKindResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B9FDBEACF232BA4330A518 /* PeriodKindResponseAdapter.swift */; };
-		9588FD4FD988C1F4CA93948F /* ConseilClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188ACB3031C05C0613EF388D /* ConseilClient+Promises.swift */; };
+		963E92E6248582A1CD1D9468 /* OperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2A43B6B3647D2CE712D1B0 /* OperationPayload.swift */; };
+		96A66AB60FF3CA3AD8A08F17 /* InjectOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2CD91AC2A1310E66E207E /* InjectOperationRPC.swift */; };
+		96B8D6BD4B20067EA9F462E7 /* ConseilPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8554205D6B899410689D280F /* ConseilPlatform.swift */; };
 		972613143D2A849C24BEFB7B /* TezosKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D4CC2EFE37BC672A082A9F69 /* TezosKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		974929D34C3D10F2D91820F9 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B73FFA1626222EBAE4742B /* Operation.swift */; };
 		9769709381BE01B6150C5500 /* TezosNodeIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7032899C34EC0CB096B9A57C /* TezosNodeIntegrationTests.swift */; };
-		97EAC0F9BFF327EB8B716452 /* GetSentTransactionsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE25FD8ADF3F006F814010C1 /* GetSentTransactionsRPC.swift */; };
-		98ED221ABABD2E1291C9362F /* MichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09931DD8D7F26A072CE8A8B9 /* MichelsonParameter.swift */; };
-		996125BBDCDA1A1C9006151F /* AbstractOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC26F84F8B3A41F9BFA19FBE /* AbstractOperation.swift */; };
+		9772DD096F27A43644A5BE4B /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53D59AD9EA44F6B351A350F /* Transaction.swift */; };
+		99A8DDEC1498C877C4C5F662 /* DelegationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170AD904F169111FBCD93FCC /* DelegationOperation.swift */; };
+		99BF2A59BBAE320C233218AE /* GetExpectedQuorumRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E006B0AA63CD2D50D07762F /* GetExpectedQuorumRPC.swift */; };
+		99EF9D9DD18902B98C5B2739 /* ConseilNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11388A975CDB5601AFC99189 /* ConseilNetwork.swift */; };
+		9A1BE88DCC44E98E1D85C26C /* IntegerResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109F98709DCC0A5351158718 /* IntegerResponseAdapter.swift */; };
 		9ACC5804F3B0BD26D25223CC /* JSONDictionaryResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF3F1D59FA8A152B8A66043A /* JSONDictionaryResponseAdapterTest.swift */; };
-		9B0BD8D2A6B8765CB3AA92BD /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04563738936938705E01305C /* Header.swift */; };
 		9B22F93D4284980497E94D9E /* TezosKitErrorCodesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4254B915770CD924FBBE9D /* TezosKitErrorCodesTest.swift */; };
-		9CB4F3C409A1B8A25D5EAE3F /* StringMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFF391D431DA3CC3AEB3ECF /* StringMichelsonParameter.swift */; };
-		9CF989385BC8CDA3ACC192D6 /* TezosKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F111F39DB1DADB91993646C7 /* TezosKitError.swift */; };
-		9D47CE7663A9A3EA6737E233 /* StringMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFF391D431DA3CC3AEB3ECF /* StringMichelsonParameter.swift */; };
+		9B3002D8742780ABC34C5C10 /* SimulationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BFF651BFE4E4A3E90313FA9 /* SimulationService.swift */; };
+		9C490216EE45DD3B2D5FA043 /* OperationWithCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04781056C289A009489C072C /* OperationWithCounter.swift */; };
 		9DBE484969D7E6B3A53C8EFC /* PeriodKindResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33048AAA1D1966A1A89E409F /* PeriodKindResponseAdapterTest.swift */; };
+		9DCFB0E5181C64B30B7C0260 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B1E1C9C5236B52B797EFA7 /* Address.swift */; };
+		9DF0E0967190DD6291844766 /* OperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB59AEAEB019E7B641B448B1 /* OperationFactory.swift */; };
 		9E6EFCDB62128E8D81DE0A28 /* Base58Swift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A7284743A69C9A12186E4D67 /* Base58Swift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9F31F9E168283B47ED4DF870 /* GetBallotsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0D366C40486A00374DF8CE /* GetBallotsRPC.swift */; };
-		9FFCB2DDD4E917B216382AFE /* ConseilEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D05B324BA34CBCC7042F74 /* ConseilEntity.swift */; };
+		9E976F554FF98E5E0BB1B232 /* PreapplicationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F74BC96BBBBF950226E07E85 /* PreapplicationService.swift */; };
 		A0B6D82615E5DCF70E37D5EB /* Base58Swift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A7284743A69C9A12186E4D67 /* Base58Swift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A16AB8A466D6E16DBEBAEC05 /* ForgingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76F5486F9A024F623CF067A6 /* ForgingPolicy.swift */; };
+		A119F0B0B84DED49D2BDF2A0 /* GetChainHeadHashRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA4823FE108BF24AC51A10 /* GetChainHeadHashRPC.swift */; };
 		A179D2426984A3AE45527544 /* Base58Swift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F47131DE435D053FC8DE2DBF /* Base58Swift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A222B28FC706D6619258D151 /* OperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB03CEC43425522539E21D70 /* OperationPayload.swift */; };
 		A26BF0891BE26654AB683DF1 /* DelegationOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35169AC0F795C07FA8AC1ED /* DelegationOperationTest.swift */; };
+		A28CACC9D1FF82076A876DEE /* RightMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6400970C08C18B3CAD121530 /* RightMichelsonParameter.swift */; };
 		A367ECAE3F91FFB06320C691 /* TransactionsResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2DD3668D2DD62AF8EDD738 /* TransactionsResponseAdapterTest.swift */; };
-		A4029AFA8212085C2E11E38F /* GetOriginatedContractsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A34A9046970ADD98F3AEFA4 /* GetOriginatedContractsRPC.swift */; };
-		A48A92F8DD14D9EB0E15D4D3 /* OperationMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9A18B2AAA829EB754C4751 /* OperationMetadataProvider.swift */; };
-		A4B38EF5D74E2CA7B4F8D365 /* ForgeOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648A9318AA4B4BB80432C534 /* ForgeOperationRPC.swift */; };
 		A4F85C0954646854BED31139 /* MnemonicUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7863872FECCF90A64CFD1F99 /* MnemonicUtil.swift */; };
+		A52003C0498A19CF87EB06A0 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5EBE1E77B4458B18D149C1 /* Operation.swift */; };
 		A5BA4DFA80A9734ED61F1BC6 /* InjectOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4090B8A708287039DE6178F4 /* InjectOperationRPCTest.swift */; };
-		A7B734AB8EF2AB2C2B6E49F2 /* SimulationResultResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD314650F87F3E86690D19A /* SimulationResultResponseAdapter.swift */; };
-		A8370D299ACA9380FBDADB09 /* GasLimitPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0FF13E4D9C5918D8D37D91D /* GasLimitPolicy.swift */; };
-		A96D27DE9A0270B550523E42 /* GetContractStorageRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5DEBE164AA357B20FDE72D /* GetContractStorageRPC.swift */; };
-		AABB5CBBD979089DBAA793E8 /* AbstractOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC26F84F8B3A41F9BFA19FBE /* AbstractOperation.swift */; };
-		AB1BEEC2FDC0BC2FC0233EAF /* JSONArrayResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F0240ACA4D780227FFDAED /* JSONArrayResponseAdapter.swift */; };
+		AB844D81BBE08DCFBD9FFF79 /* ForgingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99191D08E7D0F08C52254D6B /* ForgingPolicy.swift */; };
+		ABAB89B9D4772B56744185DA /* GetReceivedTransactions.RPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0675B789B9F5EF98BC4E4568 /* GetReceivedTransactions.RPC.swift */; };
 		ABF7C4AC4C0765F1F6FBD781 /* MichelsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2ED9478409396EF8CA5E053 /* MichelsonTests.swift */; };
 		AC47C3A79F0C0866F80FA592 /* TezosCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39FE75C2C5F5177A3F3C6752 /* TezosCrypto.framework */; };
-		AC65C3E0276EFBAB0AAC1F3F /* DelegationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E694BC28D2B08EEF39AAB889 /* DelegationOperation.swift */; };
 		AD014018539F58666D7A2ED5 /* JSONUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9983FD251855D94BAF486306 /* JSONUtilsTest.swift */; };
 		AD7BF60763ABCBEE5ECC7C6E /* SimulationResultResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7C3270399D4C501F334311 /* SimulationResultResponseAdapterTest.swift */; };
-		AD7E61D1390EADE4288EBD6B /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2138A72B60E6669BDAE1DDEF /* Transaction.swift */; };
 		AD9A89B079CEF14CD0313A3C /* OperationFactoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A33A07A0728F3091018D933 /* OperationFactoryTest.swift */; };
-		AEAD53A2EEC5B56BB0C0B594 /* IntegerResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CA4FAC6E902A5E05242E80 /* IntegerResponseAdapter.swift */; };
-		B0E88B45AE7601D8A7C71267 /* ConseilPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E123058BE0184D7A37813AD /* ConseilPlatform.swift */; };
+		ADF7981B00CA77B702135F4F /* SimulationResultResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A251461CA96978E44F48E8D /* SimulationResultResponseAdapter.swift */; };
+		AE83DAF69E3ADD93C33F0B44 /* SignedProtocolOperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2FD2E17433D630AA933B5B /* SignedProtocolOperationPayload.swift */; };
+		B00C58996BCA758752DD3B17 /* TezResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCF068374D26E5AD6CE93407 /* TezResponseAdapter.swift */; };
+		B03C7F8E33843942E97FCF88 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B1E1C9C5236B52B797EFA7 /* Address.swift */; };
+		B0AD205420E9186FFBDF591A /* GetAddressBalanceRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8BF4B1C7E42EB59D27150B /* GetAddressBalanceRPC.swift */; };
+		B1E5191F0BB57EF3A72555FC /* LeftMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18257A644A0B08F1E48E8808 /* LeftMichelsonParameter.swift */; };
 		B1E9F548F060C57569EBF95A /* GetBallotsListRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99377915F3FBFFD013D5DEA1 /* GetBallotsListRPCTest.swift */; };
+		B2FF44BEDF48FEE044D2AC91 /* StringResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7576BC92BBEFE7EA9AAB39 /* StringResponseAdapter.swift */; };
+		B31F6416DEDAC6D3A73BF97E /* ConseilNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11388A975CDB5601AFC99189 /* ConseilNetwork.swift */; };
 		B36A567790DC7ED9A75FFDAB /* ConseilPlatformTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EF1D7D0F6C1FC15B1F0600 /* ConseilPlatformTest.swift */; };
+		B3EC358C389D30BCBEE9B261 /* FeeEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F58CAE6BB7F9A44407F558B /* FeeEstimator.swift */; };
 		B40E2228FC3F0223041E0528 /* ForgingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A2247E719CDA0FA064FBD3 /* ForgingServiceTests.swift */; };
-		B40F5CEFF646D32F7C8DBBEB /* JSONArrayResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F0240ACA4D780227FFDAED /* JSONArrayResponseAdapter.swift */; };
 		B4611E1E829267F34851D7D6 /* TezosKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 632B9078CDB2B8EC754A858F /* TezosKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B481FCFB6820FB7C37019455 /* OperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2A43B6B3647D2CE712D1B0 /* OperationPayload.swift */; };
 		B490164F9531419B3EB829EC /* Sodium.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6F588414A4E9819AFC69197D /* Sodium.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		B4B7079F7BBA32D7CDC19DA9 /* ConseilQueryRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7020E9FBC44BF5513C0B1454 /* ConseilQueryRPC.swift */; };
+		B4CE5A171E1ED4CBA547A3BF /* ConseilPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8554205D6B899410689D280F /* ConseilPlatform.swift */; };
 		B501B6B383C72657C2072EFE /* RPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD86A783D877B296C9F1EFC2 /* RPCTest.swift */; };
+		B511E62F850E8E2F3BD41094 /* StringMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCF66588A24A65AA37CC90C /* StringMichelsonParameter.swift */; };
 		B5FFE6258A7B9E96E00F4D95 /* MnemonicKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 61EDBE7577517E6ACF2498A2 /* MnemonicKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B64AABC322DABBC3FD3F16FC /* RPCResponseHandlerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD174BFAC4ED4214E582E4D /* RPCResponseHandlerTest.swift */; };
-		B678F76B097B824A7C104102 /* ConseilNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = B519E8A279DDEFD7B15D8A79 /* ConseilNetwork.swift */; };
 		B6A30CF9892539BC990F4C4E /* WalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1596A9E29DF24E63C454D2DD /* WalletTests.swift */; };
-		B6E30745FA42D9357CD6484B /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3490545B084E3FB481BF1B7 /* TezosNodeClient+Promises.swift */; };
 		B7132554B9F700D768670C58 /* RevealOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E04ED6C09C75468839B5F3 /* RevealOperationTest.swift */; };
 		B7EE1249DCA7738604AA5F5B /* RPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD86A783D877B296C9F1EFC2 /* RPCTest.swift */; };
-		B83F0040C05754C876246BC0 /* SigningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E00624B1C53DDE6AF8A9C2 /* SigningService.swift */; };
 		B8F8E590F5D535715B905D3C /* ConseilNetworkTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63AB3DCEF101AC8B5CB3BEBD /* ConseilNetworkTest.swift */; };
 		B93ACE04CF55FA0F6590FACF /* Sodium.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6F588414A4E9819AFC69197D /* Sodium.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B975E1A393B383D03960996A /* BytesMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3CEDF87CB74674EF5E2BB5 /* BytesMichelsonParameter.swift */; };
 		B98235229D9B719522F50864 /* DexterExchangeClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD41CEB7ECEE9702B9C8B24 /* DexterExchangeClientTests.swift */; };
 		B994572ABA098EEB4461FF25 /* DexterExchangeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A79D50BFF252A790D5E91E5 /* DexterExchangeClient.swift */; };
+		B995FA190438FAC10CCCF28B /* TransactionOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84ECF4C95D1743641BEF321 /* TransactionOperation.swift */; };
 		B9EA37018F37B38C1D25516B /* TezosKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4CC2EFE37BC672A082A9F69 /* TezosKit.framework */; };
 		BA6FFD1D552DD5AFDE23CBA3 /* Sodium.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BCD4318870B3E4FE3F27C60D /* Sodium.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BB3E4EB39F9C57319B35C31C /* OperationMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9A18B2AAA829EB754C4751 /* OperationMetadataProvider.swift */; };
-		BB835B6B1FCA5113CF3C7109 /* ConseilPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E123058BE0184D7A37813AD /* ConseilPlatform.swift */; };
 		BBA273218EBA5CCC1FD54319 /* InjectionServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443F94AEAF2C38E5B751E7EC /* InjectionServiceTest.swift */; };
-		BCCF3EF1538523DD8578E173 /* RevealOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B028588E2CA02E910DA28DA /* RevealOperation.swift */; };
-		BE0C2E109FA99CA957F9CA63 /* AbstractMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8D4BAA248CCB8092FBF3B3 /* AbstractMichelsonParameter.swift */; };
-		BE1CB24218F8167326C5EAE0 /* RunOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25142F4DE87022CF0EDD8C9 /* RunOperationRPC.swift */; };
-		BE26FAF95EBE6A477F181C19 /* StringResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB37423CE931B84272136EE6 /* StringResponseAdapter.swift */; };
-		BEDA35A9C03589A31F6DF851 /* OperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72ABB0C779885F2546CA5D72 /* OperationFactory.swift */; };
+		BCE3F98F723E8ED5400723A1 /* GetBigMapValueRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0577D28D7A8761465FE76F9 /* GetBigMapValueRPC.swift */; };
 		BEFD63E317CD24603BFD7134 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B3BE4BAECB893457A44FC1 /* TestHelpers.swift */; };
 		BF58AA3718890216B35F94D1 /* SigningServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DD030C2ACB7856608B34BA /* SigningServiceTests.swift */; };
-		BF7E8EACB99F1756B230059F /* SimulationResultResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD314650F87F3E86690D19A /* SimulationResultResponseAdapter.swift */; };
+		BF8368AEC93713FD0257CB2A /* AbstractOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BC48461432501639D06FD6 /* AbstractOperation.swift */; };
 		C0382A1E21312C3D3323732F /* BigInt.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7806BE5035AB3100BA7C791C /* BigInt.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		C09F38C7684F82939B482072 /* ForgingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401294647448C99634146C3B /* ForgingService.swift */; };
 		C0FE1015DACEF52DD7FE3A33 /* TezosKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 632B9078CDB2B8EC754A858F /* TezosKit.framework */; };
-		C13CD3FA76C8751C518ABBBD /* RPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE3CB631E923E870E32F6A5 /* RPC.swift */; };
-		C2A770578B6D88B232AE9EA6 /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3490545B084E3FB481BF1B7 /* TezosNodeClient+Promises.swift */; };
+		C15CDCE9A538AB91764BCE7E /* LeftMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18257A644A0B08F1E48E8808 /* LeftMichelsonParameter.swift */; };
 		C3449CF9473642AADC85DC42 /* MichelsonAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362C94B98BAA147AB9D080DC /* MichelsonAnnotationTests.swift */; };
-		C362525493F2B9A0927CB178 /* SomeMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45943100AD65BB1C4061AA7 /* SomeMichelsonParameter.swift */; };
+		C35BAE30B5D78DD325FFA296 /* PeriodKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FEF269B74ED2BB4A9C9FB8 /* PeriodKind.swift */; };
 		C37EAE70D14C8C100D05D211 /* GetProposalUnderEvaluationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A43F54FBE7049C2AAE4183 /* GetProposalUnderEvaluationRPCTest.swift */; };
+		C3933C0BED7B1BD0010AE4FA /* ConseilEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C935B8FA02AA0F4D639B200 /* ConseilEntity.swift */; };
 		C4235B7DC047B5DD73741DE2 /* GetAddressManagerKeyRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB03476DB47F37A923ABB15 /* GetAddressManagerKeyRPCTest.swift */; };
+		C454DDB3DECD20CCCCEE02AB /* NetworkClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E81E509282B154977477905 /* NetworkClient+Promises.swift */; };
+		C59529A854409FB4806D2369 /* GetChainHeadHashRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA4823FE108BF24AC51A10 /* GetChainHeadHashRPC.swift */; };
 		C5971B2AD3A770CAC779C482 /* TezosKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4CC2EFE37BC672A082A9F69 /* TezosKit.framework */; };
+		C5A5A45C65BF1CFAC428C422 /* RunOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC51B27A148DD74109FEB276 /* RunOperationRPC.swift */; };
 		C5EC5863AB162329BCD66123 /* IntegerResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC964601A972639F6CEDDF75 /* IntegerResponseAdapterTest.swift */; };
-		C62B123372ED5FC4C57F9473 /* OperationMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DED6974896647B77A906EB /* OperationMetadata.swift */; };
 		C6AAFF78C788015D767EB6B8 /* TezResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88F56EE382535F0A59A52E76 /* TezResponseAdapterTest.swift */; };
+		C6C549A79623A9E2FD3D418E /* TezosKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754389C145F7AF7208CBBD41 /* TezosKitError.swift */; };
+		C7EC814C5823F266A4D6E3CF /* TransactionsResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A00D85C90C2E12DDC02E709 /* TransactionsResponseAdapter.swift */; };
+		CA01543E526BB78E930BE2BE /* PairMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7B9AE14DF5799CA2EEFDCD9 /* PairMichelsonParameter.swift */; };
 		CA1D45FBFC1AE51FA26EF101 /* ForgeOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3C6101EC3A6572348C068C /* ForgeOperationRPCTest.swift */; };
 		CA9D9A55194F6D04127C4AF9 /* JSONArrayResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C842EEAE2CDE5CE4F0C326 /* JSONArrayResponseAdapterTest.swift */; };
+		CAC10984218AF43F7C858A7C /* SimulationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6736E66F6C33A71E96D8AA57 /* SimulationResult.swift */; };
+		CB2EFDA5DD8A6BFCE675809F /* GetAddressBalanceRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8BF4B1C7E42EB59D27150B /* GetAddressBalanceRPC.swift */; };
 		CB3AD1B74FA5EBE364B99D49 /* DexterExchangeClientIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F5DCCA68E890BE7185F769 /* DexterExchangeClientIntegrationTests.swift */; };
-		CB418AED8F5243CA936F2A1B /* ResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DD98E74C85F222A0944B8EC /* ResponseAdapter.swift */; };
 		CBBFE369C8B642B4ED2FB7D0 /* GetAddressManagerKeyRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB03476DB47F37A923ABB15 /* GetAddressManagerKeyRPCTest.swift */; };
-		CE6C8AAF29BD5BE9F3F12645 /* IntMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4ED43C9050345A945D625 /* IntMichelsonParameter.swift */; };
+		CD09D6ADC165E072F1941888 /* SignedOperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = A700A211C7AB1E92C5D7C3F4 /* SignedOperationPayload.swift */; };
+		CD91A216AE335648B059C1C8 /* OperationMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A057E76CA636DDEE045ED59C /* OperationMetadataProvider.swift */; };
 		CEBD84B8EFB1C8AC632BE650 /* TransactionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8230197EBFE429B4C99611 /* TransactionTest.swift */; };
-		CF3F90CC3987E4D24A3CC586 /* SignedProtocolOperationPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3A9E501C57BFCAACBE8097 /* SignedProtocolOperationPayload.swift */; };
-		D191E0B37503B0286308DB36 /* JSONDictionaryResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03192BD63A21CFBD8D392FAF /* JSONDictionaryResponseAdapter.swift */; };
+		D0504B3FFA0DF83B7DE3A235 /* RPCResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D884FB468334AB4A1BB1C6A /* RPCResponseHandler.swift */; };
+		D197ECDB0CE8D9806CA2DF33 /* StringResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7576BC92BBEFE7EA9AAB39 /* StringResponseAdapter.swift */; };
 		D1E0A06649C26B1A59142941 /* TezosNodeIntegrationTests+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900000AC3F1E51ABDB97459A /* TezosNodeIntegrationTests+Promises.swift */; };
 		D1E5255C45564AD602F2144B /* FakeObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4465D045474BB982821D86 /* FakeObjects.swift */; };
-		D2CF73123947C4E3142DD149 /* SimulationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A61A9EA0FA8878B570608F2 /* SimulationResult.swift */; };
+		D2B18425D41696E86B26A322 /* GetVotingDelegateRightsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBD6A96F194F57F5A9AE2DA /* GetVotingDelegateRightsRPC.swift */; };
 		D3CCCC07096A97A328B93B13 /* RPCResponseHandlerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD174BFAC4ED4214E582E4D /* RPCResponseHandlerTest.swift */; };
+		D3E2F1400C41E92F55451367 /* PreapplyOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B033280AD0AE71CF00F15555 /* PreapplyOperationRPC.swift */; };
 		D445EE1F54141ACD6014D443 /* MnemonicKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD4B1012288DD6F90E8C78A /* MnemonicKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D52008AE9352DF041114112E /* PreapplyOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A315C0647D194726E8C2ECA /* PreapplyOperationRPC.swift */; };
-		D79BA94F95424AFC61425E90 /* OperationWithCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E537FD113A64E725641F52 /* OperationWithCounter.swift */; };
+		D7480678E5E575974B3692D7 /* BytesMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3CEDF87CB74674EF5E2BB5 /* BytesMichelsonParameter.swift */; };
+		D7BE1B36BA48E3EF78E8D88A /* TezosProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B059E31F2A63807B325D4115 /* TezosProtocol.swift */; };
 		D7BF3E0BD873DA969B967580 /* TezosNodeIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7032899C34EC0CB096B9A57C /* TezosNodeIntegrationTests.swift */; };
-		D853B14CBF5076D9D53CA6F6 /* GetExpectedQuorumRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30609498C728BF9A84131DD2 /* GetExpectedQuorumRPC.swift */; };
 		D867A7026A6E246C8319C0E4 /* AbstractOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5FAF254AF66B1A805ABF27 /* AbstractOperationTest.swift */; };
-		D87424DB9C4B6C9565E68A30 /* SomeMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45943100AD65BB1C4061AA7 /* SomeMichelsonParameter.swift */; };
+		D98B97305EDA7C6CDEEB8533 /* JSONArrayResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 039C325259AE4DD3416B4F30 /* JSONArrayResponseAdapter.swift */; };
 		DAB2C96A2F10A124E40ABB1A /* MnemonicKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61EDBE7577517E6ACF2498A2 /* MnemonicKit.framework */; };
 		DAB469501CBBA2BC3259F563 /* TransactionOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8539A22E432B9FCA2191C6F3 /* TransactionOperationTest.swift */; };
-		DB49F847109120980938CF8D /* MichelsonAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82DFE5FA302C7A796117730E /* MichelsonAnnotation.swift */; };
+		DACADEC72463D0CE8063EBBA /* OperationFees.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009F72EE9B4FAB81EA63A88E /* OperationFees.swift */; };
+		DB6EA6FF18BEC9B88F56F40D /* GetProposalUnderEvaluationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407B756EB7320CC968E1C2ED /* GetProposalUnderEvaluationRPC.swift */; };
 		DB9D8A24F4E1BADBC532528E /* TokenContractClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8CAB1EBF88156948D30F4 /* TokenContractClient.swift */; };
+		DBB6BA7F5BA4F6525A350D22 /* RevealOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9497DCBC4C3BE5334CF8BC59 /* RevealOperation.swift */; };
 		DBE66F45A55F10273BFF06B1 /* GetChainHeadRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4252DFDE63B35970A3B59A /* GetChainHeadRPCTest.swift */; };
+		DBFC5E6F2589F05F86749E79 /* GetOriginatedAccountsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66957E41DB2A3F6E370C7964 /* GetOriginatedAccountsRPC.swift */; };
+		DC0009944D0F8DF693A323C0 /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2344402EC93A8166B86CFAE /* Header.swift */; };
 		DC1E1E56237DA3D9D9658F46 /* GetCurrentPeriodKindRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED831CC057088D0986D62D11 /* GetCurrentPeriodKindRPCTest.swift */; };
-		DC35FF69DF2F985AB7D8F2E7 /* FeeEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55D2867D9C408D2B95898ADA /* FeeEstimator.swift */; };
-		DC5715F6556341DE84AF0821 /* GetAddressManagerKeyRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A0F3B28B28D6070679E253 /* GetAddressManagerKeyRPC.swift */; };
 		DC9C8834E1D992263ED86CBA /* TransactionOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8539A22E432B9FCA2191C6F3 /* TransactionOperationTest.swift */; };
-		DD36580D944333AC73129E1F /* GetProposalsListRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37D3CF0B119086AAA9239B4 /* GetProposalsListRPC.swift */; };
-		DD9243045CC8CF3BEF0D4D72 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = A274D251232DCED41C4EE21A /* Address.swift */; };
+		DE76843D18B4E20B091CFE2F /* AbstractResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29024177105AD82662279805 /* AbstractResponseAdapter.swift */; };
 		DFD9A90F3093E54A39B695BC /* GetVotingDelegateRightsRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39091129CFF302C9A24A91C3 /* GetVotingDelegateRightsRPCTest.swift */; };
-		E001A484C34BA6EDB0CD0EBF /* TezosKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F111F39DB1DADB91993646C7 /* TezosKitError.swift */; };
+		E022CE8D061446BAB1DEF80F /* NetworkClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E81E509282B154977477905 /* NetworkClient+Promises.swift */; };
 		E05C6F3D3223E979E5DCA5C2 /* MnemonicUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7863872FECCF90A64CFD1F99 /* MnemonicUtil.swift */; };
 		E07DF9AE68C9FA30B47CA36C /* ConseilClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3615893425C81BD4E9E677D /* ConseilClient.swift */; };
-		E0B8C5581F686BDEC7969BED /* PreapplyOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A315C0647D194726E8C2ECA /* PreapplyOperationRPC.swift */; };
-		E1315A753CF5F5636EC2BC75 /* GetChainHeadHashRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32BF326F6AE9E5C4CA060A3E /* GetChainHeadHashRPC.swift */; };
-		E13D9D7D1C4617CE9B918C33 /* PreapplicationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0D3BC47F4385A7FC52AD88 /* PreapplicationService.swift */; };
-		E13EAECF4B2361AF70D947B4 /* GetBigMapValueRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04749A677766E0B141A86229 /* GetBigMapValueRPC.swift */; };
+		E0959E31A8070943401A504B /* ConseilQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB45514356C89019DB00E50 /* ConseilQuery.swift */; };
+		E15E9B606007A7798D79926D /* BoolMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04B3A5C6B64BB78285FD5F6 /* BoolMichelsonParameter.swift */; };
 		E1BA99AD0B1A4AECDD2A8ADD /* DelegationOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35169AC0F795C07FA8AC1ED /* DelegationOperationTest.swift */; };
 		E26EA01A1CBE78934F1DB018 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B3BE4BAECB893457A44FC1 /* TestHelpers.swift */; };
-		E2B239E8643E5F51B77C3E6F /* BoolMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4FDF0314325E4EF8A1A6C2 /* BoolMichelsonParameter.swift */; };
 		E2F309725BF25B205C05A6AE /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AC64BA50EF400CF4B90951AA /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E565D4EC8A4CCF33E6DBB8FB /* InjectOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2CD91AC2A1310E66E207E /* InjectOperationRPC.swift */; };
 		E5A68008EC346FFCD3D4E654 /* GetBigMapValueRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66310D79AAEC83514BB1F0F8 /* GetBigMapValueRPCTest.swift */; };
+		E65D8132F4164B73EF0B68DC /* Tez.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6EF4B87FBEBB73B166F339 /* Tez.swift */; };
 		E6ADE3A5AA3B2E3DBB49A515 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AFC77643CD2C374042E0B932 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E6C177A320C8098EC9B4A86F /* PublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C67169ED922069E2D7A0A5 /* PublicKey.swift */; };
 		E8BD3E22C5E7C3C85A6E3379 /* FakeObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4465D045474BB982821D86 /* FakeObjects.swift */; };
 		E97BCA66FE0C6E211FDBA80F /* SipHash.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B7186F1A7293750C49649CB /* SipHash.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		EA2C9B989EF046C2166AA220 /* RPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE3CB631E923E870E32F6A5 /* RPC.swift */; };
-		EB503183CFD54E89B2B9570A /* PublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F295C6AC52D42CE43FB618F /* PublicKey.swift */; };
+		E99BFF3E63A3086672E2E46D /* GetBallotsListRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF606714D021D4EFFA07E6A /* GetBallotsListRPC.swift */; };
+		EA7CAAC03CEEC69CF5828734 /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6AA3CAB521F463866CFB96 /* TezosNodeClient+Promises.swift */; };
+		EB8DB4F131248748EB318F10 /* RevealOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9497DCBC4C3BE5334CF8BC59 /* RevealOperation.swift */; };
+		EBB75619AA9E3C31007B00C1 /* DefaultFeeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66D157EC9056A7A23FBC45D /* DefaultFeeProvider.swift */; };
 		EBDAB7D416FD0AEDB67DB575 /* TokenContractClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A10B24E2BC78C098FCC8042 /* TokenContractClientTests.swift */; };
-		ED01B7FBB425A12A653B58DE /* ForgeOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648A9318AA4B4BB80432C534 /* ForgeOperationRPC.swift */; };
 		EDA29AC8F0817C3413B88661 /* GetAddressCounterRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C525A21D32496E9B7BB4F79A /* GetAddressCounterRPCTest.swift */; };
-		EE04960F9E50C9CB360B702F /* AbstractResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8057B4D69396C9B0D6C3476D /* AbstractResponseAdapter.swift */; };
-		EFA3BD08DF624F7F7CC0E8AE /* IntMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4ED43C9050345A945D625 /* IntMichelsonParameter.swift */; };
-		EFBFF09498771152C91D0BD6 /* GetVotingDelegateRightsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B6E931C81E3260C22CF2F78 /* GetVotingDelegateRightsRPC.swift */; };
+		EF0F55C1C1ABD3474DADDF52 /* SimulationResultResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A251461CA96978E44F48E8D /* SimulationResultResponseAdapter.swift */; };
 		F009C015BB8F2701C05948E0 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFC77643CD2C374042E0B932 /* CryptoSwift.framework */; };
 		F02EF161A4EBA2A49463B0D2 /* BigInt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7806BE5035AB3100BA7C791C /* BigInt.framework */; };
 		F0554E411FB5C2572BC7F5A6 /* GetDelegateRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA474C90E513C4377433A85C /* GetDelegateRPCTest.swift */; };
 		F0AEE76F37F8405989F53A1A /* PromiseKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 33A83E353521083164433924 /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F0BB964AA315DE1D5FCB89DF /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5EBE1E77B4458B18D149C1 /* Operation.swift */; };
+		F20D1C720BE42B84FF5C3F60 /* OperationPayloadFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE0279DC6099EED8F2D4CF9 /* OperationPayloadFactory.swift */; };
 		F26AA961D4B0EC32849B8C50 /* DexterExchangeClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A79D50BFF252A790D5E91E5 /* DexterExchangeClient.swift */; };
 		F2BE1E0B9228FC9A887C4EC3 /* TezosCrypto.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D02267ED3BD3130460D19101 /* TezosCrypto.framework */; };
 		F2EB65B5F6C112EC1BB42B12 /* ConseilEntityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA46CF630A8512DF758EB2E2 /* ConseilEntityTest.swift */; };
 		F3298A11EF09E44FDEF8DBDA /* DexterExchangeClientIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F5DCCA68E890BE7185F769 /* DexterExchangeClientIntegrationTests.swift */; };
-		F375BAF808910E35297BC335 /* OperationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6B134F7A1B3563395024FC /* OperationKind.swift */; };
-		F3D701E5F127354344EEC7D5 /* GetOriginatedAccountsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56FC8C7F6ED8DB1389FE2B8E /* GetOriginatedAccountsRPC.swift */; };
-		F441F8FEB06F973B6E0591C3 /* PairMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE985D5D40374131C51C3D3 /* PairMichelsonParameter.swift */; };
-		F44420361914CD58DF21A0A7 /* GetSentTransactionsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE25FD8ADF3F006F814010C1 /* GetSentTransactionsRPC.swift */; };
-		F4BB20A0CB960B63E969EA04 /* BytesMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0AEFED21F731CED4DC60270 /* BytesMichelsonParameter.swift */; };
-		F51E22D2FA898BB10BC77021 /* MichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09931DD8D7F26A072CE8A8B9 /* MichelsonParameter.swift */; };
-		F57C49A9619FC62F796AB03B /* GetProposalUnderEvaluationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBE32BE1DE6E1950D9B55EE8 /* GetProposalUnderEvaluationRPC.swift */; };
-		F5CE0943B359985D41AD0AFA /* OperationFees.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9A9185EB72DCD21724F958 /* OperationFees.swift */; };
-		F6115CFFAB366B06EA61F582 /* InjectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D2924E8F0BF0C9EA55CF17B /* InjectionService.swift */; };
+		F4103197E94000D5141C3316 /* IntMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC8C35C8541E0CBE377968D /* IntMichelsonParameter.swift */; };
+		F4F64ABB93F7DEDF78BFBB6F /* OperationFees.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009F72EE9B4FAB81EA63A88E /* OperationFees.swift */; };
+		F5010FF130B65BA032BA1C31 /* ForgeOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAF8AE07E00BB723F1C5F139 /* ForgeOperationRPC.swift */; };
+		F5EE3E4DED51F38477AED282 /* AbstractMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8A19E59C8D7BEEA9368BE4 /* AbstractMichelsonParameter.swift */; };
 		F64A31F20AFD809EE41CCA02 /* OperationFactoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A33A07A0728F3091018D933 /* OperationFactoryTest.swift */; };
 		F67AA457A2052215F46D22C3 /* ConseilClientIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1968AE0A3A2B4DAD756FD72 /* ConseilClientIntegrationTests.swift */; };
-		F72C34BD3C6F7F74438467C4 /* SimulationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE36695F3C93A5DB12218A6E /* SimulationService.swift */; };
 		F7DA8FC104D17AEC891A61BE /* StringResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B474664A9C0C8EA93EA08 /* StringResponseAdapterTest.swift */; };
 		F808CE08290F42ED19C06B78 /* IntegerResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC964601A972639F6CEDDF75 /* IntegerResponseAdapterTest.swift */; };
-		F9DFC2AA466107B108D0E68E /* UnitMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8720218B885AA9BD6720D237 /* UnitMichelsonParameter.swift */; };
+		F9BE3DBB7109326574DD8821 /* GetBigMapValueRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0577D28D7A8761465FE76F9 /* GetBigMapValueRPC.swift */; };
 		FA69D591490F2E93C465A258 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC64BA50EF400CF4B90951AA /* CryptoSwift.framework */; };
 		FAFE54CF7E5E0BC0D60B460E /* PromiseKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 33A83E353521083164433924 /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		FBBAADD343C41B70C9F8CE5C /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = A274D251232DCED41C4EE21A /* Address.swift */; };
 		FC62BE3B01BE1641A8EA8FAC /* MnemonicUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3D7B0277CE3BF6560DFD91 /* MnemonicUtilsTest.swift */; };
 		FCFF1137D39FC8613661D401 /* SimulationResultResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7C3270399D4C501F334311 /* SimulationResultResponseAdapterTest.swift */; };
 		FD6C74F4210D79D6F9EDF7B7 /* ConseilClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BCD5416B3E149D9389F6961 /* ConseilClientTests.swift */; };
 		FD8D56FBADDCB8B8F8EA3AA6 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33A83E353521083164433924 /* PromiseKit.framework */; };
 		FDCC6491367A975FED20B230 /* RevealOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E04ED6C09C75468839B5F3 /* RevealOperationTest.swift */; };
-		FDD6C87B68DB0737240A7109 /* RightMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B964675925220276FC8DAD2C /* RightMichelsonParameter.swift */; };
 		FEFBD0AE42D0285E2DBFAEDB /* TezTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CF8E4119383EA36202FE25 /* TezTest.swift */; };
 		FF22BE227A596B34169CB10B /* ConseilClientIntegrationTests+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B2484FD06C8D95BB5ACDCC /* ConseilClientIntegrationTests+Promises.swift */; };
-		FF701EB99B831D8923C57B11 /* GetOriginatedAccountsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56FC8C7F6ED8DB1389FE2B8E /* GetOriginatedAccountsRPC.swift */; };
-		FFD14B38AC94C4085259CC1B /* NetworkClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4F07ABD79921FDF2F0DF6A /* NetworkClient+Promises.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -528,202 +528,202 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		009F72EE9B4FAB81EA63A88E /* OperationFees.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationFees.swift; sourceTree = "<group>"; };
 		01A461E89A11A327962A4232 /* SignedOperationPayloadTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedOperationPayloadTest.swift; sourceTree = "<group>"; };
-		03192BD63A21CFBD8D392FAF /* JSONDictionaryResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDictionaryResponseAdapter.swift; sourceTree = "<group>"; };
-		04563738936938705E01305C /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
-		04749A677766E0B141A86229 /* GetBigMapValueRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBigMapValueRPC.swift; sourceTree = "<group>"; };
-		077C78A023A80EBCC499DCDA /* GetAddressCounterRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressCounterRPC.swift; sourceTree = "<group>"; };
-		09931DD8D7F26A072CE8A8B9 /* MichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonParameter.swift; sourceTree = "<group>"; };
-		0A315C0647D194726E8C2ECA /* PreapplyOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreapplyOperationRPC.swift; sourceTree = "<group>"; };
-		0C148FC35AEA121D656379C4 /* SignedOperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedOperationPayload.swift; sourceTree = "<group>"; };
+		039C325259AE4DD3416B4F30 /* JSONArrayResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONArrayResponseAdapter.swift; sourceTree = "<group>"; };
+		04781056C289A009489C072C /* OperationWithCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationWithCounter.swift; sourceTree = "<group>"; };
+		06027E9BA1340E098E769026 /* GetAddressDelegateRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressDelegateRPC.swift; sourceTree = "<group>"; };
+		0675B789B9F5EF98BC4E4568 /* GetReceivedTransactions.RPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetReceivedTransactions.RPC.swift; sourceTree = "<group>"; };
+		08FEF269B74ED2BB4A9C9FB8 /* PeriodKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodKind.swift; sourceTree = "<group>"; };
+		0922D1ADC86CC9907C3EEBA2 /* ConseilClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConseilClient+Promises.swift"; sourceTree = "<group>"; };
+		0A251461CA96978E44F48E8D /* SimulationResultResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationResultResponseAdapter.swift; sourceTree = "<group>"; };
+		0BFF651BFE4E4A3E90313FA9 /* SimulationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationService.swift; sourceTree = "<group>"; };
+		0C4387729ED2573C33E3320F /* Wallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallet.swift; sourceTree = "<group>"; };
+		0F58CAE6BB7F9A44407F558B /* FeeEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeEstimator.swift; sourceTree = "<group>"; };
+		109F98709DCC0A5351158718 /* IntegerResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerResponseAdapter.swift; sourceTree = "<group>"; };
+		11388A975CDB5601AFC99189 /* ConseilNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilNetwork.swift; sourceTree = "<group>"; };
 		11DF61B717DBD0486D2AADF2 /* NetworkClientTest+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkClientTest+Promises.swift"; sourceTree = "<group>"; };
-		11E00624B1C53DDE6AF8A9C2 /* SigningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningService.swift; sourceTree = "<group>"; };
 		11EF1D7D0F6C1FC15B1F0600 /* ConseilPlatformTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilPlatformTest.swift; sourceTree = "<group>"; };
 		14C842EEAE2CDE5CE4F0C326 /* JSONArrayResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONArrayResponseAdapterTest.swift; sourceTree = "<group>"; };
+		1564F45DEFBC0D755FAB0218 /* GetSentTransactionsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSentTransactionsRPC.swift; sourceTree = "<group>"; };
 		1596A9E29DF24E63C454D2DD /* WalletTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTests.swift; sourceTree = "<group>"; };
-		188ACB3031C05C0613EF388D /* ConseilClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConseilClient+Promises.swift"; sourceTree = "<group>"; };
-		1937A6487F44E50C4E03FEF5 /* RPCResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCResponseHandler.swift; sourceTree = "<group>"; };
-		1A34A9046970ADD98F3AEFA4 /* GetOriginatedContractsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOriginatedContractsRPC.swift; sourceTree = "<group>"; };
+		170AD904F169111FBCD93FCC /* DelegationOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegationOperation.swift; sourceTree = "<group>"; };
+		18257A644A0B08F1E48E8808 /* LeftMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftMichelsonParameter.swift; sourceTree = "<group>"; };
 		1BCD5416B3E149D9389F6961 /* ConseilClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilClientTests.swift; sourceTree = "<group>"; };
+		1DC8C35C8541E0CBE377968D /* IntMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntMichelsonParameter.swift; sourceTree = "<group>"; };
 		1DD41CEB7ECEE9702B9C8B24 /* DexterExchangeClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DexterExchangeClientTests.swift; sourceTree = "<group>"; };
 		1DD4B1012288DD6F90E8C78A /* MnemonicKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = MnemonicKit.framework; sourceTree = "<group>"; };
-		1E123058BE0184D7A37813AD /* ConseilPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilPlatform.swift; sourceTree = "<group>"; };
 		1EC56B6DF6FF924206963D52 /* FeeEstimatorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeEstimatorTest.swift; sourceTree = "<group>"; };
-		20B9FDBEACF232BA4330A518 /* PeriodKindResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodKindResponseAdapter.swift; sourceTree = "<group>"; };
-		2138A72B60E6669BDAE1DDEF /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
+		2035C617A6D99FFB50ED1842 /* ForgingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgingService.swift; sourceTree = "<group>"; };
+		207E6BD1F08A190CAD16F7AA /* OperationFeePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationFeePolicy.swift; sourceTree = "<group>"; };
 		21DD030C2ACB7856608B34BA /* SigningServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningServiceTests.swift; sourceTree = "<group>"; };
-		23A0F3B28B28D6070679E253 /* GetAddressManagerKeyRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressManagerKeyRPC.swift; sourceTree = "<group>"; };
-		2448ECF9B1DEED57061162E8 /* DefaultFeeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeeProvider.swift; sourceTree = "<group>"; };
-		2482509F6BCADAE0E05A6F6B /* GetAddressBalanceRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressBalanceRPC.swift; sourceTree = "<group>"; };
-		25D05B324BA34CBCC7042F74 /* ConseilEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilEntity.swift; sourceTree = "<group>"; };
-		25FFA7CD21B5166D4B00FE81 /* InjectOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectOperationRPC.swift; sourceTree = "<group>"; };
 		274E2A45E6EB2DCA9A6D1E3F /* OperationWithCounterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationWithCounterTest.swift; sourceTree = "<group>"; };
+		29024177105AD82662279805 /* AbstractResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractResponseAdapter.swift; sourceTree = "<group>"; };
+		2B1E035A6252AD79E6A4AAD1 /* SigningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningService.swift; sourceTree = "<group>"; };
 		2B3D7B0277CE3BF6560DFD91 /* MnemonicUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MnemonicUtilsTest.swift; sourceTree = "<group>"; };
-		2B6E931C81E3260C22CF2F78 /* GetVotingDelegateRightsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetVotingDelegateRightsRPC.swift; sourceTree = "<group>"; };
-		2EA5396954524AB7F00F7087 /* GetReceivedTransactions.RPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetReceivedTransactions.RPC.swift; sourceTree = "<group>"; };
 		2FFED1AB3870A0537888D39E /* GetChainHeadHashRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChainHeadHashRPCTest.swift; sourceTree = "<group>"; };
-		30609498C728BF9A84131DD2 /* GetExpectedQuorumRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetExpectedQuorumRPC.swift; sourceTree = "<group>"; };
 		31A43F54FBE7049C2AAE4183 /* GetProposalUnderEvaluationRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProposalUnderEvaluationRPCTest.swift; sourceTree = "<group>"; };
-		32BF326F6AE9E5C4CA060A3E /* GetChainHeadHashRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChainHeadHashRPC.swift; sourceTree = "<group>"; };
-		32F0240ACA4D780227FFDAED /* JSONArrayResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONArrayResponseAdapter.swift; sourceTree = "<group>"; };
+		31F867E1CE5F1920E101259B /* GasLimitPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GasLimitPolicy.swift; sourceTree = "<group>"; };
 		32F4925116A936510F4B1176 /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PromiseKit.framework; sourceTree = "<group>"; };
 		33048AAA1D1966A1A89E409F /* PeriodKindResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodKindResponseAdapterTest.swift; sourceTree = "<group>"; };
 		33A83E353521083164433924 /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PromiseKit.framework; sourceTree = "<group>"; };
-		35391E8EF3DDA108123FA448 /* GetChainHeadRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChainHeadRPC.swift; sourceTree = "<group>"; };
 		35CD7E1718D9928582CA4984 /* NetworkClientTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClientTest.swift; sourceTree = "<group>"; };
+		361D83203112185AC915DDD2 /* InjectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectionService.swift; sourceTree = "<group>"; };
 		362C94B98BAA147AB9D080DC /* MichelsonAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonAnnotationTests.swift; sourceTree = "<group>"; };
 		37006AE33DD9117CB4E6FC9F /* GetProposalsListRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProposalsListRPCTest.swift; sourceTree = "<group>"; };
-		381654F03DF6614286E0CA1D /* GetAddressDelegateRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressDelegateRPC.swift; sourceTree = "<group>"; };
+		38FFC7595908A6BC3424370C /* GetChainHeadRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChainHeadRPC.swift; sourceTree = "<group>"; };
 		39091129CFF302C9A24A91C3 /* GetVotingDelegateRightsRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetVotingDelegateRightsRPCTest.swift; sourceTree = "<group>"; };
 		39FE75C2C5F5177A3F3C6752 /* TezosCrypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = TezosCrypto.framework; sourceTree = "<group>"; };
 		3A33A07A0728F3091018D933 /* OperationFactoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationFactoryTest.swift; sourceTree = "<group>"; };
-		3AD53D15FDED0B9265AC96E1 /* Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hex.swift; sourceTree = "<group>"; };
+		3A7576BC92BBEFE7EA9AAB39 /* StringResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringResponseAdapter.swift; sourceTree = "<group>"; };
 		3B7186F1A7293750C49649CB /* SipHash.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SipHash.framework; sourceTree = "<group>"; };
-		3BE3CB631E923E870E32F6A5 /* RPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPC.swift; sourceTree = "<group>"; };
+		3CCF66588A24A65AA37CC90C /* StringMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringMichelsonParameter.swift; sourceTree = "<group>"; };
 		3D0AD0F585AD355B45543613 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		401294647448C99634146C3B /* ForgingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgingService.swift; sourceTree = "<group>"; };
+		3D6EF4B87FBEBB73B166F339 /* Tez.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tez.swift; sourceTree = "<group>"; };
+		3D81337F4A5B2C502DB3D076 /* OperationKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationKind.swift; sourceTree = "<group>"; };
 		4072A0AC0434DA705B972883 /* TezosKitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TezosKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		407B756EB7320CC968E1C2ED /* GetProposalUnderEvaluationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProposalUnderEvaluationRPC.swift; sourceTree = "<group>"; };
 		4090B8A708287039DE6178F4 /* InjectOperationRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectOperationRPCTest.swift; sourceTree = "<group>"; };
 		443F94AEAF2C38E5B751E7EC /* InjectionServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectionServiceTest.swift; sourceTree = "<group>"; };
 		47259C26A53DB562B22F087B /* CodingUtilTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodingUtilTest.swift; sourceTree = "<group>"; };
-		491C8771799EBFE1EEB5A40A /* MichelsonComparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonComparable.swift; sourceTree = "<group>"; };
-		4F0D366C40486A00374DF8CE /* GetBallotsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBallotsRPC.swift; sourceTree = "<group>"; };
-		522E98DE7193F42BCB3CF361 /* TransactionOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionOperation.swift; sourceTree = "<group>"; };
+		4C935B8FA02AA0F4D639B200 /* ConseilEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilEntity.swift; sourceTree = "<group>"; };
+		4E006B0AA63CD2D50D07762F /* GetExpectedQuorumRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetExpectedQuorumRPC.swift; sourceTree = "<group>"; };
+		525C931C7CD120487B51DA9A /* MichelsonComparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonComparable.swift; sourceTree = "<group>"; };
 		53BA885B9E3E1F6BA3693A3F /* SignedProtocolOperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedProtocolOperationPayload.swift; sourceTree = "<group>"; };
 		55B2484FD06C8D95BB5ACDCC /* ConseilClientIntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConseilClientIntegrationTests+Promises.swift"; sourceTree = "<group>"; };
-		55D2867D9C408D2B95898ADA /* FeeEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeeEstimator.swift; sourceTree = "<group>"; };
-		55DF562D0F0EB275D1CDF473 /* TezosProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosProtocol.swift; sourceTree = "<group>"; };
-		56FC8C7F6ED8DB1389FE2B8E /* GetOriginatedAccountsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOriginatedAccountsRPC.swift; sourceTree = "<group>"; };
-		5B9A9185EB72DCD21724F958 /* OperationFees.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationFees.swift; sourceTree = "<group>"; };
+		588112F5BDBF5213EB952EF1 /* NoneMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoneMichelsonParameter.swift; sourceTree = "<group>"; };
 		5BD174BFAC4ED4214E582E4D /* RPCResponseHandlerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCResponseHandlerTest.swift; sourceTree = "<group>"; };
-		5DD98E74C85F222A0944B8EC /* ResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseAdapter.swift; sourceTree = "<group>"; };
 		5E2DD3668D2DD62AF8EDD738 /* TransactionsResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsResponseAdapterTest.swift; sourceTree = "<group>"; };
+		6067C4058BC42C52B64AF93A /* Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hex.swift; sourceTree = "<group>"; };
 		61EDBE7577517E6ACF2498A2 /* MnemonicKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = MnemonicKit.framework; sourceTree = "<group>"; };
 		632B9078CDB2B8EC754A858F /* TezosKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TezosKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63AB3DCEF101AC8B5CB3BEBD /* ConseilNetworkTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilNetworkTest.swift; sourceTree = "<group>"; };
-		642373BEB9D3145F37EC1D68 /* TezosNodeClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosNodeClient.swift; sourceTree = "<group>"; };
-		648A9318AA4B4BB80432C534 /* ForgeOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgeOperationRPC.swift; sourceTree = "<group>"; };
+		6400970C08C18B3CAD121530 /* RightMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightMichelsonParameter.swift; sourceTree = "<group>"; };
+		653FD23DE712676D0DFCA7D2 /* JSONDictionaryResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDictionaryResponseAdapter.swift; sourceTree = "<group>"; };
 		66310D79AAEC83514BB1F0F8 /* GetBigMapValueRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBigMapValueRPCTest.swift; sourceTree = "<group>"; };
+		66957E41DB2A3F6E370C7964 /* GetOriginatedAccountsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOriginatedAccountsRPC.swift; sourceTree = "<group>"; };
+		6736E66F6C33A71E96D8AA57 /* SimulationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationResult.swift; sourceTree = "<group>"; };
 		67BF17864BD54D09DB6CE2FA /* OperationMetadataProviderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMetadataProviderTest.swift; sourceTree = "<group>"; };
 		6AF9ECBC79C00C0B082798EB /* GetBallotsRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBallotsRPCTest.swift; sourceTree = "<group>"; };
 		6B4465D045474BB982821D86 /* FakeObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeObjects.swift; sourceTree = "<group>"; };
-		6D18AF3E00B8343E3EA6793B /* TezResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezResponseAdapter.swift; sourceTree = "<group>"; };
-		6D2924E8F0BF0C9EA55CF17B /* InjectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectionService.swift; sourceTree = "<group>"; };
-		6EA4ED43C9050345A945D625 /* IntMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntMichelsonParameter.swift; sourceTree = "<group>"; };
+		6B8A19E59C8D7BEEA9368BE4 /* AbstractMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractMichelsonParameter.swift; sourceTree = "<group>"; };
+		6D884FB468334AB4A1BB1C6A /* RPCResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCResponseHandler.swift; sourceTree = "<group>"; };
+		6E81E509282B154977477905 /* NetworkClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkClient+Promises.swift"; sourceTree = "<group>"; };
 		6EF6AE2D1FDA4575445E424F /* TezosKitIntegrationTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TezosKitIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		6F295C6AC52D42CE43FB618F /* PublicKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKey.swift; sourceTree = "<group>"; };
 		6F588414A4E9819AFC69197D /* Sodium.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sodium.framework; sourceTree = "<group>"; };
-		7020E9FBC44BF5513C0B1454 /* ConseilQueryRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilQueryRPC.swift; sourceTree = "<group>"; };
+		7008A9105E3151B6B23496F1 /* GetOriginatedContractsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetOriginatedContractsRPC.swift; sourceTree = "<group>"; };
 		7032899C34EC0CB096B9A57C /* TezosNodeIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosNodeIntegrationTests.swift; sourceTree = "<group>"; };
 		717CE63EDCDACE20EFDEF9A6 /* GetContractStorageRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContractStorageRPCTest.swift; sourceTree = "<group>"; };
-		72ABB0C779885F2546CA5D72 /* OperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationFactory.swift; sourceTree = "<group>"; };
 		737132D7F972BD110818F565 /* SipHash.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SipHash.framework; sourceTree = "<group>"; };
-		74DED6974896647B77A906EB /* OperationMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMetadata.swift; sourceTree = "<group>"; };
-		75CA4FAC6E902A5E05242E80 /* IntegerResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerResponseAdapter.swift; sourceTree = "<group>"; };
-		76F5486F9A024F623CF067A6 /* ForgingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgingPolicy.swift; sourceTree = "<group>"; };
+		754389C145F7AF7208CBBD41 /* TezosKitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosKitError.swift; sourceTree = "<group>"; };
 		77CF8E4119383EA36202FE25 /* TezTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezTest.swift; sourceTree = "<group>"; };
 		7806BE5035AB3100BA7C791C /* BigInt.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = BigInt.framework; sourceTree = "<group>"; };
 		7863872FECCF90A64CFD1F99 /* MnemonicUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MnemonicUtil.swift; sourceTree = "<group>"; };
 		7A10B24E2BC78C098FCC8042 /* TokenContractClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenContractClientTests.swift; sourceTree = "<group>"; };
-		7A61A9EA0FA8878B570608F2 /* SimulationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationResult.swift; sourceTree = "<group>"; };
 		7A79D50BFF252A790D5E91E5 /* DexterExchangeClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DexterExchangeClient.swift; sourceTree = "<group>"; };
+		7B2A43B6B3647D2CE712D1B0 /* OperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationPayload.swift; sourceTree = "<group>"; };
+		7C07BA2584C54711181C33DE /* GetContractStorageRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContractStorageRPC.swift; sourceTree = "<group>"; };
 		7D8230197EBFE429B4C99611 /* TransactionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionTest.swift; sourceTree = "<group>"; };
-		8057B4D69396C9B0D6C3476D /* AbstractResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractResponseAdapter.swift; sourceTree = "<group>"; };
-		82DFE5FA302C7A796117730E /* MichelsonAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonAnnotation.swift; sourceTree = "<group>"; };
-		83E537FD113A64E725641F52 /* OperationWithCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationWithCounter.swift; sourceTree = "<group>"; };
-		84C8ED8DF8D7C503E41656D3 /* LeftMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftMichelsonParameter.swift; sourceTree = "<group>"; };
-		84CD16AED7E1BA31C1679402 /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
+		7DF606714D021D4EFFA07E6A /* GetBallotsListRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBallotsListRPC.swift; sourceTree = "<group>"; };
+		81BC48461432501639D06FD6 /* AbstractOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractOperation.swift; sourceTree = "<group>"; };
+		82B64C2C9B1E8CA1987CC98B /* PeriodKindResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodKindResponseAdapter.swift; sourceTree = "<group>"; };
 		8539A22E432B9FCA2191C6F3 /* TransactionOperationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionOperationTest.swift; sourceTree = "<group>"; };
+		8554205D6B899410689D280F /* ConseilPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilPlatform.swift; sourceTree = "<group>"; };
 		86A2630E0DE0D72091FD3AE5 /* TezosKitIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TezosKitIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		8720218B885AA9BD6720D237 /* UnitMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitMichelsonParameter.swift; sourceTree = "<group>"; };
 		88F56EE382535F0A59A52E76 /* TezResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezResponseAdapterTest.swift; sourceTree = "<group>"; };
+		8A00D85C90C2E12DDC02E709 /* TransactionsResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsResponseAdapter.swift; sourceTree = "<group>"; };
 		8A1D2B885A5A1D1477E020C5 /* GetAddressBalanceRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressBalanceRPCTest.swift; sourceTree = "<group>"; };
 		8AE8CAB1EBF88156948D30F4 /* TokenContractClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenContractClient.swift; sourceTree = "<group>"; };
-		8B028588E2CA02E910DA28DA /* RevealOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevealOperation.swift; sourceTree = "<group>"; };
 		8F1D1F6B1DDF04EB174551D3 /* TestObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestObjects.swift; sourceTree = "<group>"; };
 		900000AC3F1E51ABDB97459A /* TezosNodeIntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeIntegrationTests+Promises.swift"; sourceTree = "<group>"; };
-		91787089B3FFEBEB100961FE /* PeriodKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodKind.swift; sourceTree = "<group>"; };
-		92B73FFA1626222EBAE4742B /* Operation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operation.swift; sourceTree = "<group>"; };
+		908CE3F01F463AD656302DFD /* MichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonParameter.swift; sourceTree = "<group>"; };
+		90D9A0CB32FB707D9BF32654 /* ResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseAdapter.swift; sourceTree = "<group>"; };
+		933679D90DA718BAE1ECF1ED /* GetCurrentPeriodKindRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentPeriodKindRPC.swift; sourceTree = "<group>"; };
+		9497DCBC4C3BE5334CF8BC59 /* RevealOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevealOperation.swift; sourceTree = "<group>"; };
 		95A67597F73AC6D20F83B677 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		95F395F6CD3F62BF5D3FCED1 /* BigInt.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = BigInt.framework; sourceTree = "<group>"; };
+		99191D08E7D0F08C52254D6B /* ForgingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgingPolicy.swift; sourceTree = "<group>"; };
 		99377915F3FBFFD013D5DEA1 /* GetBallotsListRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBallotsListRPCTest.swift; sourceTree = "<group>"; };
 		9983FD251855D94BAF486306 /* JSONUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONUtilsTest.swift; sourceTree = "<group>"; };
+		9A02A5F41589CD0850ED45F8 /* RPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPC.swift; sourceTree = "<group>"; };
 		9A992D50CBFAFC7476FCD3D6 /* TezosKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TezosKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		9A9A18B2AAA829EB754C4751 /* OperationMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMetadataProvider.swift; sourceTree = "<group>"; };
 		9C0C00172340567CB1919631 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		9E4FDF0314325E4EF8A1A6C2 /* BoolMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolMichelsonParameter.swift; sourceTree = "<group>"; };
-		9EE87395F6EA86F5E466AFBB /* NoneMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoneMichelsonParameter.swift; sourceTree = "<group>"; };
-		9F711CF77E0E756B9C7A707F /* GetBallotsListRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBallotsListRPC.swift; sourceTree = "<group>"; };
-		A083D21A561E16A7E8267BB8 /* GetCurrentPeriodKindRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentPeriodKindRPC.swift; sourceTree = "<group>"; };
-		A0AEFED21F731CED4DC60270 /* BytesMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BytesMichelsonParameter.swift; sourceTree = "<group>"; };
+		9F6AA3CAB521F463866CFB96 /* TezosNodeClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeClient+Promises.swift"; sourceTree = "<group>"; };
+		A057E76CA636DDEE045ED59C /* OperationMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMetadataProvider.swift; sourceTree = "<group>"; };
+		A0A82D9C70BEC192B4D73809 /* TezosNodeClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosNodeClient.swift; sourceTree = "<group>"; };
 		A17556CA46001F8FB5DF8302 /* JSONUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONUtils.swift; sourceTree = "<group>"; };
 		A227FD388A5B50891D5C7FE1 /* RunOperationRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunOperationRPCTest.swift; sourceTree = "<group>"; };
-		A274D251232DCED41C4EE21A /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 		A2ED9478409396EF8CA5E053 /* MichelsonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonTests.swift; sourceTree = "<group>"; };
 		A3615893425C81BD4E9E677D /* ConseilClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilClient.swift; sourceTree = "<group>"; };
 		A480E400F3C3D065639376F4 /* TezosNodeClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosNodeClientTests.swift; sourceTree = "<group>"; };
+		A4B1E1C9C5236B52B797EFA7 /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
+		A4BE9708692F1E9BEFA4B1DA /* OperationMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMetadata.swift; sourceTree = "<group>"; };
+		A700A211C7AB1E92C5D7C3F4 /* SignedOperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedOperationPayload.swift; sourceTree = "<group>"; };
 		A7284743A69C9A12186E4D67 /* Base58Swift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Base58Swift.framework; sourceTree = "<group>"; };
+		A84ECF4C95D1743641BEF321 /* TransactionOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionOperation.swift; sourceTree = "<group>"; };
 		AA46CF630A8512DF758EB2E2 /* ConseilEntityTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilEntityTest.swift; sourceTree = "<group>"; };
-		AC2B5D0CAE285FAC9FE43EE3 /* OperationPayloadFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationPayloadFactory.swift; sourceTree = "<group>"; };
+		AAF8AE07E00BB723F1C5F139 /* ForgeOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgeOperationRPC.swift; sourceTree = "<group>"; };
+		AB59AEAEB019E7B641B448B1 /* OperationFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationFactory.swift; sourceTree = "<group>"; };
 		AC64BA50EF400CF4B90951AA /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CryptoSwift.framework; sourceTree = "<group>"; };
-		AC90AB66610CCED41A30ED13 /* OperationFeePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationFeePolicy.swift; sourceTree = "<group>"; };
 		AC964601A972639F6CEDDF75 /* IntegerResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerResponseAdapterTest.swift; sourceTree = "<group>"; };
+		AD2FD2E17433D630AA933B5B /* SignedProtocolOperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedProtocolOperationPayload.swift; sourceTree = "<group>"; };
 		AD5FAF254AF66B1A805ABF27 /* AbstractOperationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractOperationTest.swift; sourceTree = "<group>"; };
-		AE25FD8ADF3F006F814010C1 /* GetSentTransactionsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSentTransactionsRPC.swift; sourceTree = "<group>"; };
+		AE3CEDF87CB74674EF5E2BB5 /* BytesMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BytesMichelsonParameter.swift; sourceTree = "<group>"; };
 		AF4254B915770CD924FBBE9D /* TezosKitErrorCodesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosKitErrorCodesTest.swift; sourceTree = "<group>"; };
 		AFC77643CD2C374042E0B932 /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CryptoSwift.framework; sourceTree = "<group>"; };
+		B01627EE910CBE5821502281 /* GetAddressManagerKeyRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressManagerKeyRPC.swift; sourceTree = "<group>"; };
+		B033280AD0AE71CF00F15555 /* PreapplyOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreapplyOperationRPC.swift; sourceTree = "<group>"; };
+		B059E31F2A63807B325D4115 /* TezosProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosProtocol.swift; sourceTree = "<group>"; };
 		B35169AC0F795C07FA8AC1ED /* DelegationOperationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegationOperationTest.swift; sourceTree = "<group>"; };
-		B37D3CF0B119086AAA9239B4 /* GetProposalsListRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProposalsListRPC.swift; sourceTree = "<group>"; };
-		B45943100AD65BB1C4061AA7 /* SomeMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomeMichelsonParameter.swift; sourceTree = "<group>"; };
-		B519E8A279DDEFD7B15D8A79 /* ConseilNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilNetwork.swift; sourceTree = "<group>"; };
-		B964675925220276FC8DAD2C /* RightMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightMichelsonParameter.swift; sourceTree = "<group>"; };
-		BB11A435CDBF5E17784FD6BB /* Wallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallet.swift; sourceTree = "<group>"; };
+		B66D157EC9056A7A23FBC45D /* DefaultFeeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFeeProvider.swift; sourceTree = "<group>"; };
+		B84952454AD66BD8E378047D /* GetBallotsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBallotsRPC.swift; sourceTree = "<group>"; };
 		BB3C6101EC3A6572348C068C /* ForgeOperationRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgeOperationRPCTest.swift; sourceTree = "<group>"; };
-		BC6B134F7A1B3563395024FC /* OperationKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationKind.swift; sourceTree = "<group>"; };
-		BCD314650F87F3E86690D19A /* SimulationResultResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationResultResponseAdapter.swift; sourceTree = "<group>"; };
+		BC51B27A148DD74109FEB276 /* RunOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunOperationRPC.swift; sourceTree = "<group>"; };
 		BCD4318870B3E4FE3F27C60D /* Sodium.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Sodium.framework; sourceTree = "<group>"; };
-		BF9B3CAED5792E4AB7750AF7 /* Tez.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tez.swift; sourceTree = "<group>"; };
+		BCF068374D26E5AD6CE93407 /* TezResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezResponseAdapter.swift; sourceTree = "<group>"; };
+		BF24BCDA4254C7A2D50F5728 /* ConseilQueryRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilQueryRPC.swift; sourceTree = "<group>"; };
 		C1968AE0A3A2B4DAD756FD72 /* ConseilClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilClientIntegrationTests.swift; sourceTree = "<group>"; };
 		C1FCF6EFDB51394D49E1479C /* PreapplicationServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreapplicationServiceTest.swift; sourceTree = "<group>"; };
 		C525A21D32496E9B7BB4F79A /* GetAddressCounterRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressCounterRPCTest.swift; sourceTree = "<group>"; };
+		C714AAB4A35FE0C6B5BEB154 /* GetProposalsListRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProposalsListRPC.swift; sourceTree = "<group>"; };
 		C99F7EF575AEA6BE191F2001 /* TokenContractIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenContractIntegrationTests.swift; sourceTree = "<group>"; };
-		CA0D3BC47F4385A7FC52AD88 /* PreapplicationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreapplicationService.swift; sourceTree = "<group>"; };
-		CC26F84F8B3A41F9BFA19FBE /* AbstractOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractOperation.swift; sourceTree = "<group>"; };
-		CC3A9E501C57BFCAACBE8097 /* SignedProtocolOperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedProtocolOperationPayload.swift; sourceTree = "<group>"; };
+		CB80D50511873CF9783361B4 /* SomeMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomeMichelsonParameter.swift; sourceTree = "<group>"; };
+		CCEA4823FE108BF24AC51A10 /* GetChainHeadHashRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChainHeadHashRPC.swift; sourceTree = "<group>"; };
+		CE5EBE1E77B4458B18D149C1 /* Operation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operation.swift; sourceTree = "<group>"; };
 		CE7B474664A9C0C8EA93EA08 /* StringResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringResponseAdapterTest.swift; sourceTree = "<group>"; };
 		CEB03476DB47F37A923ABB15 /* GetAddressManagerKeyRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressManagerKeyRPCTest.swift; sourceTree = "<group>"; };
-		CF4F07ABD79921FDF2F0DF6A /* NetworkClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkClient+Promises.swift"; sourceTree = "<group>"; };
+		CF147FA8F9FDDEBA70FA2759 /* GetAddressCounterRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressCounterRPC.swift; sourceTree = "<group>"; };
+		CF8BF4B1C7E42EB59D27150B /* GetAddressBalanceRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressBalanceRPC.swift; sourceTree = "<group>"; };
+		CFB45514356C89019DB00E50 /* ConseilQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilQuery.swift; sourceTree = "<group>"; };
 		D02267ED3BD3130460D19101 /* TezosCrypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = TezosCrypto.framework; sourceTree = "<group>"; };
-		D2D552948C9850FA50ED7155 /* ConseilQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilQuery.swift; sourceTree = "<group>"; };
+		D1C67169ED922069E2D7A0A5 /* PublicKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKey.swift; sourceTree = "<group>"; };
+		D2F15CD865BE921BF9DF8CC0 /* MichelsonAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonAnnotation.swift; sourceTree = "<group>"; };
 		D4CC2EFE37BC672A082A9F69 /* TezosKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TezosKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D6051D167763077DEB139912 /* TransactionsResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsResponseAdapter.swift; sourceTree = "<group>"; };
+		D650111C52C89A65467CC889 /* UnitMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitMichelsonParameter.swift; sourceTree = "<group>"; };
 		D9F5DCCA68E890BE7185F769 /* DexterExchangeClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DexterExchangeClientIntegrationTests.swift; sourceTree = "<group>"; };
-		DEE985D5D40374131C51C3D3 /* PairMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairMichelsonParameter.swift; sourceTree = "<group>"; };
-		DF8D4BAA248CCB8092FBF3B3 /* AbstractMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractMichelsonParameter.swift; sourceTree = "<group>"; };
 		E0B48169F083D2DAEB462840 /* SimulationServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationServiceTest.swift; sourceTree = "<group>"; };
-		E0FF13E4D9C5918D8D37D91D /* GasLimitPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GasLimitPolicy.swift; sourceTree = "<group>"; };
-		E3490545B084E3FB481BF1B7 /* TezosNodeClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeClient+Promises.swift"; sourceTree = "<group>"; };
+		E212CD2F0656857B66156D04 /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		E4B3BE4BAECB893457A44FC1 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
-		E694BC28D2B08EEF39AAB889 /* DelegationOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegationOperation.swift; sourceTree = "<group>"; };
 		E7A2247E719CDA0FA064FBD3 /* ForgingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgingServiceTests.swift; sourceTree = "<group>"; };
 		E7E04ED6C09C75468839B5F3 /* RevealOperationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevealOperationTest.swift; sourceTree = "<group>"; };
-		EB03CEC43425522539E21D70 /* OperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationPayload.swift; sourceTree = "<group>"; };
-		EB37423CE931B84272136EE6 /* StringResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringResponseAdapter.swift; sourceTree = "<group>"; };
-		EBE32BE1DE6E1950D9B55EE8 /* GetProposalUnderEvaluationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetProposalUnderEvaluationRPC.swift; sourceTree = "<group>"; };
 		ED831CC057088D0986D62D11 /* GetCurrentPeriodKindRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentPeriodKindRPCTest.swift; sourceTree = "<group>"; };
-		EDFF391D431DA3CC3AEB3ECF /* StringMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringMichelsonParameter.swift; sourceTree = "<group>"; };
-		EE5DEBE164AA357B20FDE72D /* GetContractStorageRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContractStorageRPC.swift; sourceTree = "<group>"; };
 		EFE3E8D18069FFC9F79BF11D /* OperationPayloadFactoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationPayloadFactoryTest.swift; sourceTree = "<group>"; };
-		F111F39DB1DADB91993646C7 /* TezosKitError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosKitError.swift; sourceTree = "<group>"; };
+		F04B3A5C6B64BB78285FD5F6 /* BoolMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoolMichelsonParameter.swift; sourceTree = "<group>"; };
+		F0577D28D7A8761465FE76F9 /* GetBigMapValueRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBigMapValueRPC.swift; sourceTree = "<group>"; };
+		F1A2CD91AC2A1310E66E207E /* InjectOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectOperationRPC.swift; sourceTree = "<group>"; };
+		F2344402EC93A8166B86CFAE /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
 		F2415E6BE21BBCACF5128B13 /* CodingUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodingUtil.swift; sourceTree = "<group>"; };
-		F25142F4DE87022CF0EDD8C9 /* RunOperationRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunOperationRPC.swift; sourceTree = "<group>"; };
 		F47131DE435D053FC8DE2DBF /* Base58Swift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Base58Swift.framework; sourceTree = "<group>"; };
+		F53D59AD9EA44F6B351A350F /* Transaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
 		F68B50E6C20187E9AC1CDB8E /* GetExpectedQuorumRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetExpectedQuorumRPCTest.swift; sourceTree = "<group>"; };
+		F74BC96BBBBF950226E07E85 /* PreapplicationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreapplicationService.swift; sourceTree = "<group>"; };
+		F7B9AE14DF5799CA2EEFDCD9 /* PairMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairMichelsonParameter.swift; sourceTree = "<group>"; };
 		FA474C90E513C4377433A85C /* GetDelegateRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDelegateRPCTest.swift; sourceTree = "<group>"; };
+		FBE0279DC6099EED8F2D4CF9 /* OperationPayloadFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationPayloadFactory.swift; sourceTree = "<group>"; };
 		FC385B9CD31989369391F0B6 /* PreapplyOperationRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreapplyOperationRPCTest.swift; sourceTree = "<group>"; };
 		FC4252DFDE63B35970A3B59A /* GetChainHeadRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChainHeadRPCTest.swift; sourceTree = "<group>"; };
 		FD86A783D877B296C9F1EFC2 /* RPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCTest.swift; sourceTree = "<group>"; };
-		FE36695F3C93A5DB12218A6E /* SimulationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationService.swift; sourceTree = "<group>"; };
+		FDBD6A96F194F57F5A9AE2DA /* GetVotingDelegateRightsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetVotingDelegateRightsRPC.swift; sourceTree = "<group>"; };
 		FF3F1D59FA8A152B8A66043A /* JSONDictionaryResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDictionaryResponseAdapterTest.swift; sourceTree = "<group>"; };
 		FF7C3270399D4C501F334311 /* SimulationResultResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationResultResponseAdapterTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -794,34 +794,30 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		11818830052DD521DC1DCDEA /* RPC */ = {
+		0A41FFF4FAF68CE43BE0EC17 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				648A9318AA4B4BB80432C534 /* ForgeOperationRPC.swift */,
-				2482509F6BCADAE0E05A6F6B /* GetAddressBalanceRPC.swift */,
-				077C78A023A80EBCC499DCDA /* GetAddressCounterRPC.swift */,
-				381654F03DF6614286E0CA1D /* GetAddressDelegateRPC.swift */,
-				23A0F3B28B28D6070679E253 /* GetAddressManagerKeyRPC.swift */,
-				9F711CF77E0E756B9C7A707F /* GetBallotsListRPC.swift */,
-				4F0D366C40486A00374DF8CE /* GetBallotsRPC.swift */,
-				04749A677766E0B141A86229 /* GetBigMapValueRPC.swift */,
-				32BF326F6AE9E5C4CA060A3E /* GetChainHeadHashRPC.swift */,
-				35391E8EF3DDA108123FA448 /* GetChainHeadRPC.swift */,
-				EE5DEBE164AA357B20FDE72D /* GetContractStorageRPC.swift */,
-				A083D21A561E16A7E8267BB8 /* GetCurrentPeriodKindRPC.swift */,
-				30609498C728BF9A84131DD2 /* GetExpectedQuorumRPC.swift */,
-				B37D3CF0B119086AAA9239B4 /* GetProposalsListRPC.swift */,
-				EBE32BE1DE6E1950D9B55EE8 /* GetProposalUnderEvaluationRPC.swift */,
-				2B6E931C81E3260C22CF2F78 /* GetVotingDelegateRightsRPC.swift */,
-				04563738936938705E01305C /* Header.swift */,
-				25FFA7CD21B5166D4B00FE81 /* InjectOperationRPC.swift */,
-				0A315C0647D194726E8C2ECA /* PreapplyOperationRPC.swift */,
-				3BE3CB631E923E870E32F6A5 /* RPC.swift */,
-				F25142F4DE87022CF0EDD8C9 /* RunOperationRPC.swift */,
-				94F3C78F9C3A82764EFB05EB /* Payload */,
-				CEB1A78A6D59ACEB04CE2631 /* ResponseAdapters */,
+				4C935B8FA02AA0F4D639B200 /* ConseilEntity.swift */,
+				11388A975CDB5601AFC99189 /* ConseilNetwork.swift */,
+				8554205D6B899410689D280F /* ConseilPlatform.swift */,
+				CFB45514356C89019DB00E50 /* ConseilQuery.swift */,
+				F53D59AD9EA44F6B351A350F /* Transaction.swift */,
 			);
-			path = RPC;
+			path = Models;
+			sourceTree = "<group>";
+		};
+		1408D048311EA234A38711DC /* Operation */ = {
+			isa = PBXGroup;
+			children = (
+				81BC48461432501639D06FD6 /* AbstractOperation.swift */,
+				170AD904F169111FBCD93FCC /* DelegationOperation.swift */,
+				CE5EBE1E77B4458B18D149C1 /* Operation.swift */,
+				3D81337F4A5B2C502DB3D076 /* OperationKind.swift */,
+				04781056C289A009489C072C /* OperationWithCounter.swift */,
+				9497DCBC4C3BE5334CF8BC59 /* RevealOperation.swift */,
+				A84ECF4C95D1743641BEF321 /* TransactionOperation.swift */,
+			);
+			path = Operation;
 			sourceTree = "<group>";
 		};
 		17AFD0D67C2DEDCB9010CEF8 /* PromiseKit */ = {
@@ -931,13 +927,10 @@
 			isa = PBXGroup;
 			children = (
 				9C0C00172340567CB1919631 /* Info.plist */,
-				484F2A6D54217DF5F20E024F /* Client */,
+				F80C3334511B7B1FF508595C /* Common */,
 				C6FF7DDFA7E79B70081F6813 /* Conseil */,
 				2C6A4504513EE2183CF21AEE /* Dexter */,
-				55F54F1B4128BC789D8892F4 /* Michelson */,
-				5608EF94FE20E185CDC03058 /* Models */,
-				6CF4D956FF3E600B7D2485B5 /* Operation */,
-				11818830052DD521DC1DCDEA /* RPC */,
+				8DCBA0758BE9080FDE336F22 /* TezosNode */,
 				2669C60C5F0AA4189B13DD01 /* Utils */,
 			);
 			path = TezosKit;
@@ -954,6 +947,18 @@
 				9A992D50CBFAFC7476FCD3D6 /* TezosKitTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		3AACA70A73E02516E9BBFF63 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				A4B1E1C9C5236B52B797EFA7 /* Address.swift */,
+				6067C4058BC42C52B64AF93A /* Hex.swift */,
+				D1C67169ED922069E2D7A0A5 /* PublicKey.swift */,
+				3D6EF4B87FBEBB73B166F339 /* Tez.swift */,
+				0C4387729ED2573C33E3320F /* Wallet.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		3F9B9BFF99C4564DACD14E44 /* TezosKit */ = {
@@ -979,15 +984,20 @@
 			);
 			sourceTree = "<group>";
 		};
-		484F2A6D54217DF5F20E024F /* Client */ = {
+		4638FA3842C25B47CA15A7A8 /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				84CD16AED7E1BA31C1679402 /* NetworkClient.swift */,
-				1937A6487F44E50C4E03FEF5 /* RPCResponseHandler.swift */,
-				F111F39DB1DADB91993646C7 /* TezosKitError.swift */,
-				642373BEB9D3145F37EC1D68 /* TezosNodeClient.swift */,
+				E212CD2F0656857B66156D04 /* NetworkClient.swift */,
 			);
-			path = Client;
+			path = Services;
+			sourceTree = "<group>";
+		};
+		4FB8A8575ACE00EFC4FCD4BC /* Conseil */ = {
+			isa = PBXGroup;
+			children = (
+				0922D1ADC86CC9907C3EEBA2 /* ConseilClient+Promises.swift */,
+			);
+			path = Conseil;
 			sourceTree = "<group>";
 		};
 		50C91A025E54A221B684A314 /* Extensions */ = {
@@ -998,42 +1008,25 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
-		55F54F1B4128BC789D8892F4 /* Michelson */ = {
+		5764D64E1113AE8AEFC25DC1 /* Michelson */ = {
 			isa = PBXGroup;
 			children = (
-				DF8D4BAA248CCB8092FBF3B3 /* AbstractMichelsonParameter.swift */,
-				9E4FDF0314325E4EF8A1A6C2 /* BoolMichelsonParameter.swift */,
-				A0AEFED21F731CED4DC60270 /* BytesMichelsonParameter.swift */,
-				6EA4ED43C9050345A945D625 /* IntMichelsonParameter.swift */,
-				84C8ED8DF8D7C503E41656D3 /* LeftMichelsonParameter.swift */,
-				82DFE5FA302C7A796117730E /* MichelsonAnnotation.swift */,
-				491C8771799EBFE1EEB5A40A /* MichelsonComparable.swift */,
-				09931DD8D7F26A072CE8A8B9 /* MichelsonParameter.swift */,
-				9EE87395F6EA86F5E466AFBB /* NoneMichelsonParameter.swift */,
-				DEE985D5D40374131C51C3D3 /* PairMichelsonParameter.swift */,
-				B964675925220276FC8DAD2C /* RightMichelsonParameter.swift */,
-				B45943100AD65BB1C4061AA7 /* SomeMichelsonParameter.swift */,
-				EDFF391D431DA3CC3AEB3ECF /* StringMichelsonParameter.swift */,
-				8720218B885AA9BD6720D237 /* UnitMichelsonParameter.swift */,
+				6B8A19E59C8D7BEEA9368BE4 /* AbstractMichelsonParameter.swift */,
+				F04B3A5C6B64BB78285FD5F6 /* BoolMichelsonParameter.swift */,
+				AE3CEDF87CB74674EF5E2BB5 /* BytesMichelsonParameter.swift */,
+				1DC8C35C8541E0CBE377968D /* IntMichelsonParameter.swift */,
+				18257A644A0B08F1E48E8808 /* LeftMichelsonParameter.swift */,
+				D2F15CD865BE921BF9DF8CC0 /* MichelsonAnnotation.swift */,
+				525C931C7CD120487B51DA9A /* MichelsonComparable.swift */,
+				908CE3F01F463AD656302DFD /* MichelsonParameter.swift */,
+				588112F5BDBF5213EB952EF1 /* NoneMichelsonParameter.swift */,
+				F7B9AE14DF5799CA2EEFDCD9 /* PairMichelsonParameter.swift */,
+				6400970C08C18B3CAD121530 /* RightMichelsonParameter.swift */,
+				CB80D50511873CF9783361B4 /* SomeMichelsonParameter.swift */,
+				3CCF66588A24A65AA37CC90C /* StringMichelsonParameter.swift */,
+				D650111C52C89A65467CC889 /* UnitMichelsonParameter.swift */,
 			);
 			path = Michelson;
-			sourceTree = "<group>";
-		};
-		5608EF94FE20E185CDC03058 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				A274D251232DCED41C4EE21A /* Address.swift */,
-				E0FF13E4D9C5918D8D37D91D /* GasLimitPolicy.swift */,
-				3AD53D15FDED0B9265AC96E1 /* Hex.swift */,
-				5B9A9185EB72DCD21724F958 /* OperationFees.swift */,
-				74DED6974896647B77A906EB /* OperationMetadata.swift */,
-				91787089B3FFEBEB100961FE /* PeriodKind.swift */,
-				6F295C6AC52D42CE43FB618F /* PublicKey.swift */,
-				BF9B3CAED5792E4AB7750AF7 /* Tez.swift */,
-				55DF562D0F0EB275D1CDF473 /* TezosProtocol.swift */,
-				BB11A435CDBF5E17784FD6BB /* Wallet.swift */,
-			);
-			path = Models;
 			sourceTree = "<group>";
 		};
 		58A1E9B631A003766785A1FD /* Carthage */ = {
@@ -1044,6 +1037,38 @@
 			);
 			name = Carthage;
 			path = Carthage/Build;
+			sourceTree = "<group>";
+		};
+		5A2C3D6262341794E04A057B /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				99191D08E7D0F08C52254D6B /* ForgingPolicy.swift */,
+				31F867E1CE5F1920E101259B /* GasLimitPolicy.swift */,
+				207E6BD1F08A190CAD16F7AA /* OperationFeePolicy.swift */,
+				009F72EE9B4FAB81EA63A88E /* OperationFees.swift */,
+				A4BE9708692F1E9BEFA4B1DA /* OperationMetadata.swift */,
+				08FEF269B74ED2BB4A9C9FB8 /* PeriodKind.swift */,
+				6736E66F6C33A71E96D8AA57 /* SimulationResult.swift */,
+				B059E31F2A63807B325D4115 /* TezosProtocol.swift */,
+				1408D048311EA234A38711DC /* Operation */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		5B66876C281AF60F384A0631 /* TezosNode */ = {
+			isa = PBXGroup;
+			children = (
+				9F6AA3CAB521F463866CFB96 /* TezosNodeClient+Promises.swift */,
+			);
+			path = TezosNode;
+			sourceTree = "<group>";
+		};
+		61C4C7FA7CF82B3CBF223279 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				6E81E509282B154977477905 /* NetworkClient+Promises.swift */,
+			);
+			path = Common;
 			sourceTree = "<group>";
 		};
 		69291FDD3EDCCD2E9D0374A2 /* IntegrationTests */ = {
@@ -1057,31 +1082,12 @@
 			path = Tests/IntegrationTests;
 			sourceTree = "<group>";
 		};
-		6CF4D956FF3E600B7D2485B5 /* Operation */ = {
+		7B109A80330EB9E10F906C7E /* ResponseAdapters */ = {
 			isa = PBXGroup;
 			children = (
-				CC26F84F8B3A41F9BFA19FBE /* AbstractOperation.swift */,
-				2448ECF9B1DEED57061162E8 /* DefaultFeeProvider.swift */,
-				E694BC28D2B08EEF39AAB889 /* DelegationOperation.swift */,
-				55D2867D9C408D2B95898ADA /* FeeEstimator.swift */,
-				76F5486F9A024F623CF067A6 /* ForgingPolicy.swift */,
-				401294647448C99634146C3B /* ForgingService.swift */,
-				6D2924E8F0BF0C9EA55CF17B /* InjectionService.swift */,
-				92B73FFA1626222EBAE4742B /* Operation.swift */,
-				72ABB0C779885F2546CA5D72 /* OperationFactory.swift */,
-				AC90AB66610CCED41A30ED13 /* OperationFeePolicy.swift */,
-				BC6B134F7A1B3563395024FC /* OperationKind.swift */,
-				9A9A18B2AAA829EB754C4751 /* OperationMetadataProvider.swift */,
-				AC2B5D0CAE285FAC9FE43EE3 /* OperationPayloadFactory.swift */,
-				83E537FD113A64E725641F52 /* OperationWithCounter.swift */,
-				CA0D3BC47F4385A7FC52AD88 /* PreapplicationService.swift */,
-				8B028588E2CA02E910DA28DA /* RevealOperation.swift */,
-				11E00624B1C53DDE6AF8A9C2 /* SigningService.swift */,
-				7A61A9EA0FA8878B570608F2 /* SimulationResult.swift */,
-				FE36695F3C93A5DB12218A6E /* SimulationService.swift */,
-				522E98DE7193F42BCB3CF361 /* TransactionOperation.swift */,
+				8A00D85C90C2E12DDC02E709 /* TransactionsResponseAdapter.swift */,
 			);
-			path = Operation;
+			path = ResponseAdapters;
 			sourceTree = "<group>";
 		};
 		881A92144450BF6091D9A3C3 /* Mac */ = {
@@ -1099,14 +1105,31 @@
 			path = Mac;
 			sourceTree = "<group>";
 		};
-		94F3C78F9C3A82764EFB05EB /* Payload */ = {
+		8DCBA0758BE9080FDE336F22 /* TezosNode */ = {
 			isa = PBXGroup;
 			children = (
-				EB03CEC43425522539E21D70 /* OperationPayload.swift */,
-				0C148FC35AEA121D656379C4 /* SignedOperationPayload.swift */,
-				CC3A9E501C57BFCAACBE8097 /* SignedProtocolOperationPayload.swift */,
+				A0A82D9C70BEC192B4D73809 /* TezosNodeClient.swift */,
+				5A2C3D6262341794E04A057B /* Models */,
+				EE00741DC28C1AF320F7296B /* RPC */,
+				FCC6037F1523DBBA76B695E0 /* Services */,
 			);
-			path = Payload;
+			path = TezosNode;
+			sourceTree = "<group>";
+		};
+		B144422D7A4B52462CE26C3A /* ResponseAdapters */ = {
+			isa = PBXGroup;
+			children = (
+				29024177105AD82662279805 /* AbstractResponseAdapter.swift */,
+				109F98709DCC0A5351158718 /* IntegerResponseAdapter.swift */,
+				039C325259AE4DD3416B4F30 /* JSONArrayResponseAdapter.swift */,
+				653FD23DE712676D0DFCA7D2 /* JSONDictionaryResponseAdapter.swift */,
+				82B64C2C9B1E8CA1987CC98B /* PeriodKindResponseAdapter.swift */,
+				90D9A0CB32FB707D9BF32654 /* ResponseAdapter.swift */,
+				0A251461CA96978E44F48E8D /* SimulationResultResponseAdapter.swift */,
+				3A7576BC92BBEFE7EA9AAB39 /* StringResponseAdapter.swift */,
+				BCF068374D26E5AD6CE93407 /* TezResponseAdapter.swift */,
+			);
+			path = ResponseAdapters;
 			sourceTree = "<group>";
 		};
 		B36F9F28F19084A0DBC15D53 /* Dexter */ = {
@@ -1122,17 +1145,8 @@
 			isa = PBXGroup;
 			children = (
 				A3615893425C81BD4E9E677D /* ConseilClient.swift */,
-				25D05B324BA34CBCC7042F74 /* ConseilEntity.swift */,
-				B519E8A279DDEFD7B15D8A79 /* ConseilNetwork.swift */,
-				1E123058BE0184D7A37813AD /* ConseilPlatform.swift */,
-				D2D552948C9850FA50ED7155 /* ConseilQuery.swift */,
-				7020E9FBC44BF5513C0B1454 /* ConseilQueryRPC.swift */,
-				56FC8C7F6ED8DB1389FE2B8E /* GetOriginatedAccountsRPC.swift */,
-				1A34A9046970ADD98F3AEFA4 /* GetOriginatedContractsRPC.swift */,
-				2EA5396954524AB7F00F7087 /* GetReceivedTransactions.RPC.swift */,
-				AE25FD8ADF3F006F814010C1 /* GetSentTransactionsRPC.swift */,
-				2138A72B60E6669BDAE1DDEF /* Transaction.swift */,
-				D6051D167763077DEB139912 /* TransactionsResponseAdapter.swift */,
+				0A41FFF4FAF68CE43BE0EC17 /* Models */,
+				E61DB289673DCF1C7B4ABE01 /* RPC */,
 			);
 			path = Conseil;
 			sourceTree = "<group>";
@@ -1140,27 +1154,11 @@
 		CC3ABB10E1F3E8528B324756 /* PromiseKit */ = {
 			isa = PBXGroup;
 			children = (
-				188ACB3031C05C0613EF388D /* ConseilClient+Promises.swift */,
-				CF4F07ABD79921FDF2F0DF6A /* NetworkClient+Promises.swift */,
-				E3490545B084E3FB481BF1B7 /* TezosNodeClient+Promises.swift */,
+				61C4C7FA7CF82B3CBF223279 /* Common */,
+				4FB8A8575ACE00EFC4FCD4BC /* Conseil */,
+				5B66876C281AF60F384A0631 /* TezosNode */,
 			);
 			path = PromiseKit;
-			sourceTree = "<group>";
-		};
-		CEB1A78A6D59ACEB04CE2631 /* ResponseAdapters */ = {
-			isa = PBXGroup;
-			children = (
-				8057B4D69396C9B0D6C3476D /* AbstractResponseAdapter.swift */,
-				75CA4FAC6E902A5E05242E80 /* IntegerResponseAdapter.swift */,
-				32F0240ACA4D780227FFDAED /* JSONArrayResponseAdapter.swift */,
-				03192BD63A21CFBD8D392FAF /* JSONDictionaryResponseAdapter.swift */,
-				20B9FDBEACF232BA4330A518 /* PeriodKindResponseAdapter.swift */,
-				5DD98E74C85F222A0944B8EC /* ResponseAdapter.swift */,
-				BCD314650F87F3E86690D19A /* SimulationResultResponseAdapter.swift */,
-				EB37423CE931B84272136EE6 /* StringResponseAdapter.swift */,
-				6D18AF3E00B8343E3EA6793B /* TezResponseAdapter.swift */,
-			);
-			path = ResponseAdapters;
 			sourceTree = "<group>";
 		};
 		D231A0952D7582EAE9B5877D /* Common */ = {
@@ -1198,6 +1196,19 @@
 			path = iOS;
 			sourceTree = "<group>";
 		};
+		E61DB289673DCF1C7B4ABE01 /* RPC */ = {
+			isa = PBXGroup;
+			children = (
+				BF24BCDA4254C7A2D50F5728 /* ConseilQueryRPC.swift */,
+				66957E41DB2A3F6E370C7964 /* GetOriginatedAccountsRPC.swift */,
+				7008A9105E3151B6B23496F1 /* GetOriginatedContractsRPC.swift */,
+				0675B789B9F5EF98BC4E4568 /* GetReceivedTransactions.RPC.swift */,
+				1564F45DEFBC0D755FAB0218 /* GetSentTransactionsRPC.swift */,
+				7B109A80330EB9E10F906C7E /* ResponseAdapters */,
+			);
+			path = RPC;
+			sourceTree = "<group>";
+		};
 		E67B87D587558F51971F43BF /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -1218,12 +1229,89 @@
 			path = Dexter;
 			sourceTree = "<group>";
 		};
+		E6FA9BD7360B51E2353AFA20 /* Payload */ = {
+			isa = PBXGroup;
+			children = (
+				7B2A43B6B3647D2CE712D1B0 /* OperationPayload.swift */,
+				A700A211C7AB1E92C5D7C3F4 /* SignedOperationPayload.swift */,
+				AD2FD2E17433D630AA933B5B /* SignedProtocolOperationPayload.swift */,
+			);
+			path = Payload;
+			sourceTree = "<group>";
+		};
+		EE00741DC28C1AF320F7296B /* RPC */ = {
+			isa = PBXGroup;
+			children = (
+				AAF8AE07E00BB723F1C5F139 /* ForgeOperationRPC.swift */,
+				CF8BF4B1C7E42EB59D27150B /* GetAddressBalanceRPC.swift */,
+				CF147FA8F9FDDEBA70FA2759 /* GetAddressCounterRPC.swift */,
+				06027E9BA1340E098E769026 /* GetAddressDelegateRPC.swift */,
+				B01627EE910CBE5821502281 /* GetAddressManagerKeyRPC.swift */,
+				7DF606714D021D4EFFA07E6A /* GetBallotsListRPC.swift */,
+				B84952454AD66BD8E378047D /* GetBallotsRPC.swift */,
+				F0577D28D7A8761465FE76F9 /* GetBigMapValueRPC.swift */,
+				CCEA4823FE108BF24AC51A10 /* GetChainHeadHashRPC.swift */,
+				38FFC7595908A6BC3424370C /* GetChainHeadRPC.swift */,
+				7C07BA2584C54711181C33DE /* GetContractStorageRPC.swift */,
+				933679D90DA718BAE1ECF1ED /* GetCurrentPeriodKindRPC.swift */,
+				4E006B0AA63CD2D50D07762F /* GetExpectedQuorumRPC.swift */,
+				C714AAB4A35FE0C6B5BEB154 /* GetProposalsListRPC.swift */,
+				407B756EB7320CC968E1C2ED /* GetProposalUnderEvaluationRPC.swift */,
+				FDBD6A96F194F57F5A9AE2DA /* GetVotingDelegateRightsRPC.swift */,
+				F1A2CD91AC2A1310E66E207E /* InjectOperationRPC.swift */,
+				B033280AD0AE71CF00F15555 /* PreapplyOperationRPC.swift */,
+				BC51B27A148DD74109FEB276 /* RunOperationRPC.swift */,
+				E6FA9BD7360B51E2353AFA20 /* Payload */,
+				B144422D7A4B52462CE26C3A /* ResponseAdapters */,
+			);
+			path = RPC;
+			sourceTree = "<group>";
+		};
+		F44112D8655B4B17D2FA2C84 /* RPC */ = {
+			isa = PBXGroup;
+			children = (
+				F2344402EC93A8166B86CFAE /* Header.swift */,
+				9A02A5F41589CD0850ED45F8 /* RPC.swift */,
+			);
+			path = RPC;
+			sourceTree = "<group>";
+		};
 		F4DCE624936879BCE22A854A /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
 				E2A29ABF6DE3D847BF087B63 /* PromiseKit */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		F80C3334511B7B1FF508595C /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				754389C145F7AF7208CBBD41 /* TezosKitError.swift */,
+				5764D64E1113AE8AEFC25DC1 /* Michelson */,
+				3AACA70A73E02516E9BBFF63 /* Models */,
+				F44112D8655B4B17D2FA2C84 /* RPC */,
+				4638FA3842C25B47CA15A7A8 /* Services */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		FCC6037F1523DBBA76B695E0 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				B66D157EC9056A7A23FBC45D /* DefaultFeeProvider.swift */,
+				0F58CAE6BB7F9A44407F558B /* FeeEstimator.swift */,
+				2035C617A6D99FFB50ED1842 /* ForgingService.swift */,
+				361D83203112185AC915DDD2 /* InjectionService.swift */,
+				AB59AEAEB019E7B641B448B1 /* OperationFactory.swift */,
+				A057E76CA636DDEE045ED59C /* OperationMetadataProvider.swift */,
+				FBE0279DC6099EED8F2D4CF9 /* OperationPayloadFactory.swift */,
+				F74BC96BBBBF950226E07E85 /* PreapplicationService.swift */,
+				6D884FB468334AB4A1BB1C6A /* RPCResponseHandler.swift */,
+				2B1E035A6252AD79E6A4AAD1 /* SigningService.swift */,
+				0BFF651BFE4E4A3E90313FA9 /* SimulationService.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		FE4EEFBC6C12C0D326D4CFF0 /* Frameworks */ = {
@@ -1506,107 +1594,107 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2FC3AF915DDA64D799EEDFBA /* AbstractMichelsonParameter.swift in Sources */,
-				996125BBDCDA1A1C9006151F /* AbstractOperation.swift in Sources */,
-				6FF51F7D08A6841414E9979D /* AbstractResponseAdapter.swift in Sources */,
-				FBBAADD343C41B70C9F8CE5C /* Address.swift in Sources */,
-				E2B239E8643E5F51B77C3E6F /* BoolMichelsonParameter.swift in Sources */,
-				F4BB20A0CB960B63E969EA04 /* BytesMichelsonParameter.swift in Sources */,
+				F5EE3E4DED51F38477AED282 /* AbstractMichelsonParameter.swift in Sources */,
+				45FF7FCB7F2351BA549C6BDF /* AbstractOperation.swift in Sources */,
+				5C243C48B85DBB99E58CE34C /* AbstractResponseAdapter.swift in Sources */,
+				9DCFB0E5181C64B30B7C0260 /* Address.swift in Sources */,
+				51019358C9044908CD8DAA42 /* BoolMichelsonParameter.swift in Sources */,
+				B975E1A393B383D03960996A /* BytesMichelsonParameter.swift in Sources */,
 				4D5203CB5AE5F88C2F55ABF7 /* CodingUtil.swift in Sources */,
-				9588FD4FD988C1F4CA93948F /* ConseilClient+Promises.swift in Sources */,
+				6D8731CE158D6378887B5A33 /* ConseilClient+Promises.swift in Sources */,
 				5104508D0317778C144DC50B /* ConseilClient.swift in Sources */,
-				9FFCB2DDD4E917B216382AFE /* ConseilEntity.swift in Sources */,
-				B678F76B097B824A7C104102 /* ConseilNetwork.swift in Sources */,
-				BB835B6B1FCA5113CF3C7109 /* ConseilPlatform.swift in Sources */,
-				5963AA62543B2A7B5240E692 /* ConseilQuery.swift in Sources */,
-				B4B7079F7BBA32D7CDC19DA9 /* ConseilQueryRPC.swift in Sources */,
-				396065508F2B015FEB61A4FC /* DefaultFeeProvider.swift in Sources */,
-				3B606277954B7E779A8F4640 /* DelegationOperation.swift in Sources */,
+				C3933C0BED7B1BD0010AE4FA /* ConseilEntity.swift in Sources */,
+				B31F6416DEDAC6D3A73BF97E /* ConseilNetwork.swift in Sources */,
+				B4CE5A171E1ED4CBA547A3BF /* ConseilPlatform.swift in Sources */,
+				7E28672FA338FA3D8E163026 /* ConseilQuery.swift in Sources */,
+				26BD1B449C1BDF0A34EB3424 /* ConseilQueryRPC.swift in Sources */,
+				EBB75619AA9E3C31007B00C1 /* DefaultFeeProvider.swift in Sources */,
+				99A8DDEC1498C877C4C5F662 /* DelegationOperation.swift in Sources */,
 				F26AA961D4B0EC32849B8C50 /* DexterExchangeClient.swift in Sources */,
-				2AF6668B3DC57C241E92534F /* FeeEstimator.swift in Sources */,
-				A4B38EF5D74E2CA7B4F8D365 /* ForgeOperationRPC.swift in Sources */,
-				0BCD32493E9F69FE1FE1E816 /* ForgingPolicy.swift in Sources */,
-				C09F38C7684F82939B482072 /* ForgingService.swift in Sources */,
-				A8370D299ACA9380FBDADB09 /* GasLimitPolicy.swift in Sources */,
-				0A193A2B03ADD8C481FEC5C5 /* GetAddressBalanceRPC.swift in Sources */,
-				79E4E7544E310FE65CF96934 /* GetAddressCounterRPC.swift in Sources */,
-				33538282B4A0BEE7608532CB /* GetAddressDelegateRPC.swift in Sources */,
-				5BEF10AACEE0CD411D694597 /* GetAddressManagerKeyRPC.swift in Sources */,
-				13C4F1C0EFE12E679B198B7C /* GetBallotsListRPC.swift in Sources */,
-				9F31F9E168283B47ED4DF870 /* GetBallotsRPC.swift in Sources */,
-				E13EAECF4B2361AF70D947B4 /* GetBigMapValueRPC.swift in Sources */,
-				E1315A753CF5F5636EC2BC75 /* GetChainHeadHashRPC.swift in Sources */,
-				2DA7B278C4503B28F95D49C5 /* GetChainHeadRPC.swift in Sources */,
-				A96D27DE9A0270B550523E42 /* GetContractStorageRPC.swift in Sources */,
-				51A35E3DEFAAF1383850AFC1 /* GetCurrentPeriodKindRPC.swift in Sources */,
-				D853B14CBF5076D9D53CA6F6 /* GetExpectedQuorumRPC.swift in Sources */,
-				FF701EB99B831D8923C57B11 /* GetOriginatedAccountsRPC.swift in Sources */,
-				A4029AFA8212085C2E11E38F /* GetOriginatedContractsRPC.swift in Sources */,
-				22AA35D707876712CD2F8B7C /* GetProposalUnderEvaluationRPC.swift in Sources */,
-				0AD2208F99DFF907337836C5 /* GetProposalsListRPC.swift in Sources */,
-				247C6E5E288037EBA00E77E9 /* GetReceivedTransactions.RPC.swift in Sources */,
-				F44420361914CD58DF21A0A7 /* GetSentTransactionsRPC.swift in Sources */,
-				EFBFF09498771152C91D0BD6 /* GetVotingDelegateRightsRPC.swift in Sources */,
-				1359AB823CB70E91CACC8182 /* Header.swift in Sources */,
-				82705C677A1705DE861B5837 /* Hex.swift in Sources */,
-				6974FC94889C888118071F40 /* InjectOperationRPC.swift in Sources */,
-				32808CF2255B6C966753FC38 /* InjectionService.swift in Sources */,
-				CE6C8AAF29BD5BE9F3F12645 /* IntMichelsonParameter.swift in Sources */,
-				04AE8D3127CA774D4DF2A74B /* IntegerResponseAdapter.swift in Sources */,
-				B40F5CEFF646D32F7C8DBBEB /* JSONArrayResponseAdapter.swift in Sources */,
-				5287C9940539CF378C1BBDB8 /* JSONDictionaryResponseAdapter.swift in Sources */,
+				0E3E471E4B226BB3CF0C7493 /* FeeEstimator.swift in Sources */,
+				3F3B6E81340BD7ECFCE8FBAF /* ForgeOperationRPC.swift in Sources */,
+				00A736FA9438F4C332A56A3C /* ForgingPolicy.swift in Sources */,
+				20C16CFCB554CF81CB2CF03C /* ForgingService.swift in Sources */,
+				5C9E6119D5B8F50A8C076024 /* GasLimitPolicy.swift in Sources */,
+				CB2EFDA5DD8A6BFCE675809F /* GetAddressBalanceRPC.swift in Sources */,
+				2655ECC6A0A89FDF23DF18A6 /* GetAddressCounterRPC.swift in Sources */,
+				7E5A3D04C2B733F09D4922D6 /* GetAddressDelegateRPC.swift in Sources */,
+				26684AB4366572B8B2CD89D5 /* GetAddressManagerKeyRPC.swift in Sources */,
+				19BF852742C7D35BD097808B /* GetBallotsListRPC.swift in Sources */,
+				69D1108BBFEF81261566FF65 /* GetBallotsRPC.swift in Sources */,
+				F9BE3DBB7109326574DD8821 /* GetBigMapValueRPC.swift in Sources */,
+				A119F0B0B84DED49D2BDF2A0 /* GetChainHeadHashRPC.swift in Sources */,
+				0CD4F987EE82D3CEA1D6FD07 /* GetChainHeadRPC.swift in Sources */,
+				6D91DBD85F5F525826CC55FE /* GetContractStorageRPC.swift in Sources */,
+				528E6A128E816E8527C341C8 /* GetCurrentPeriodKindRPC.swift in Sources */,
+				99BF2A59BBAE320C233218AE /* GetExpectedQuorumRPC.swift in Sources */,
+				933B932FCB6435B861C30DE7 /* GetOriginatedAccountsRPC.swift in Sources */,
+				05242C7AF25D0B6C351BC765 /* GetOriginatedContractsRPC.swift in Sources */,
+				4FCF97E349053D21AE8E506E /* GetProposalUnderEvaluationRPC.swift in Sources */,
+				1625E43AF077065705ADBFFD /* GetProposalsListRPC.swift in Sources */,
+				ABAB89B9D4772B56744185DA /* GetReceivedTransactions.RPC.swift in Sources */,
+				40708A0C7052EF4251CD9BAC /* GetSentTransactionsRPC.swift in Sources */,
+				D2B18425D41696E86B26A322 /* GetVotingDelegateRightsRPC.swift in Sources */,
+				DC0009944D0F8DF693A323C0 /* Header.swift in Sources */,
+				3698330EA50903CD0AEEC185 /* Hex.swift in Sources */,
+				96A66AB60FF3CA3AD8A08F17 /* InjectOperationRPC.swift in Sources */,
+				56AE01634FDD6F3CC966BCEF /* InjectionService.swift in Sources */,
+				0F732C98D081BB4791AEE2B0 /* IntMichelsonParameter.swift in Sources */,
+				9A1BE88DCC44E98E1D85C26C /* IntegerResponseAdapter.swift in Sources */,
+				74702CAD5E79A2B0DA1D3494 /* JSONArrayResponseAdapter.swift in Sources */,
+				6C211B5899F3AB595386C678 /* JSONDictionaryResponseAdapter.swift in Sources */,
 				5315F49C61534B939678E39C /* JSONUtils.swift in Sources */,
-				871C12C4F112AEE8E7D21F44 /* LeftMichelsonParameter.swift in Sources */,
-				DB49F847109120980938CF8D /* MichelsonAnnotation.swift in Sources */,
-				67DA3118B1A853A9F81DABE8 /* MichelsonComparable.swift in Sources */,
-				F51E22D2FA898BB10BC77021 /* MichelsonParameter.swift in Sources */,
+				C15CDCE9A538AB91764BCE7E /* LeftMichelsonParameter.swift in Sources */,
+				92813B3FAE81849626114B08 /* MichelsonAnnotation.swift in Sources */,
+				609CBA9E58941C450A963639 /* MichelsonComparable.swift in Sources */,
+				7D7DE0D66FA04949CD3EBF56 /* MichelsonParameter.swift in Sources */,
 				A4F85C0954646854BED31139 /* MnemonicUtil.swift in Sources */,
-				0F4C3ABE5D851C831AA4025D /* NetworkClient+Promises.swift in Sources */,
-				089431F1BFBDF2DA911267FD /* NetworkClient.swift in Sources */,
-				402422891004DF57E8B73278 /* NoneMichelsonParameter.swift in Sources */,
-				974929D34C3D10F2D91820F9 /* Operation.swift in Sources */,
-				BEDA35A9C03589A31F6DF851 /* OperationFactory.swift in Sources */,
-				8C9B2596C4F5C9A80B42F1CA /* OperationFeePolicy.swift in Sources */,
-				F5CE0943B359985D41AD0AFA /* OperationFees.swift in Sources */,
-				F375BAF808910E35297BC335 /* OperationKind.swift in Sources */,
-				1D27471CB576F7E0A858317E /* OperationMetadata.swift in Sources */,
-				A48A92F8DD14D9EB0E15D4D3 /* OperationMetadataProvider.swift in Sources */,
-				28F2509DE289CE255EF909F1 /* OperationPayload.swift in Sources */,
-				06B484024F2425DF7782BE41 /* OperationPayloadFactory.swift in Sources */,
-				D79BA94F95424AFC61425E90 /* OperationWithCounter.swift in Sources */,
-				F441F8FEB06F973B6E0591C3 /* PairMichelsonParameter.swift in Sources */,
-				13BFF4B5ED4D326EC4948CE3 /* PeriodKind.swift in Sources */,
-				94D159D68D4A6283663F95A1 /* PeriodKindResponseAdapter.swift in Sources */,
-				E13D9D7D1C4617CE9B918C33 /* PreapplicationService.swift in Sources */,
-				E0B8C5581F686BDEC7969BED /* PreapplyOperationRPC.swift in Sources */,
-				93C8369FD5BAECF82E3CA67B /* PublicKey.swift in Sources */,
-				EA2C9B989EF046C2166AA220 /* RPC.swift in Sources */,
-				5EB5EA8B955EA5BE0F4B2F4A /* RPCResponseHandler.swift in Sources */,
-				CB418AED8F5243CA936F2A1B /* ResponseAdapter.swift in Sources */,
-				BCCF3EF1538523DD8578E173 /* RevealOperation.swift in Sources */,
-				FDD6C87B68DB0737240A7109 /* RightMichelsonParameter.swift in Sources */,
-				6F406259A8C7EA4959D7A21A /* RunOperationRPC.swift in Sources */,
-				0FFD5966D70D23B61C4BA7AB /* SignedOperationPayload.swift in Sources */,
-				CF3F90CC3987E4D24A3CC586 /* SignedProtocolOperationPayload.swift in Sources */,
-				3731170B8898FF878EB37A61 /* SigningService.swift in Sources */,
-				630E1EDFD10D8C4D026295A6 /* SimulationResult.swift in Sources */,
-				BF7E8EACB99F1756B230059F /* SimulationResultResponseAdapter.swift in Sources */,
-				314DC0220D09F33267BF262E /* SimulationService.swift in Sources */,
-				D87424DB9C4B6C9565E68A30 /* SomeMichelsonParameter.swift in Sources */,
-				9CB4F3C409A1B8A25D5EAE3F /* StringMichelsonParameter.swift in Sources */,
-				BE26FAF95EBE6A477F181C19 /* StringResponseAdapter.swift in Sources */,
-				0DC3D9BE7F5F7FF916F9B24C /* Tez.swift in Sources */,
-				8EC21214B05CBFE1740BC608 /* TezResponseAdapter.swift in Sources */,
-				9CF989385BC8CDA3ACC192D6 /* TezosKitError.swift in Sources */,
-				B6E30745FA42D9357CD6484B /* TezosNodeClient+Promises.swift in Sources */,
-				1977544AA681B3C2884EA342 /* TezosNodeClient.swift in Sources */,
-				0394FB37475676AEA4EF45E4 /* TezosProtocol.swift in Sources */,
+				C454DDB3DECD20CCCCEE02AB /* NetworkClient+Promises.swift in Sources */,
+				17502DA144CE9470DAEB95AA /* NetworkClient.swift in Sources */,
+				262E887F091430DD45BB3D37 /* NoneMichelsonParameter.swift in Sources */,
+				A52003C0498A19CF87EB06A0 /* Operation.swift in Sources */,
+				9DF0E0967190DD6291844766 /* OperationFactory.swift in Sources */,
+				156B321DCC4509F69AFDFEEE /* OperationFeePolicy.swift in Sources */,
+				DACADEC72463D0CE8063EBBA /* OperationFees.swift in Sources */,
+				4F0AC7852283D8C563FBAA9A /* OperationKind.swift in Sources */,
+				252A8D548EB7E2581096E4AF /* OperationMetadata.swift in Sources */,
+				CD91A216AE335648B059C1C8 /* OperationMetadataProvider.swift in Sources */,
+				963E92E6248582A1CD1D9468 /* OperationPayload.swift in Sources */,
+				85BC63DB233D9E4663D05D6B /* OperationPayloadFactory.swift in Sources */,
+				346B3C1348BED784D82EF921 /* OperationWithCounter.swift in Sources */,
+				CA01543E526BB78E930BE2BE /* PairMichelsonParameter.swift in Sources */,
+				767808D0C01FF2CB4F56C5CC /* PeriodKind.swift in Sources */,
+				27641CCD3D8C9AC9A6719869 /* PeriodKindResponseAdapter.swift in Sources */,
+				9E976F554FF98E5E0BB1B232 /* PreapplicationService.swift in Sources */,
+				D3E2F1400C41E92F55451367 /* PreapplyOperationRPC.swift in Sources */,
+				E6C177A320C8098EC9B4A86F /* PublicKey.swift in Sources */,
+				1F1BE8043A523F121852538E /* RPC.swift in Sources */,
+				491266272393A7957B05EC64 /* RPCResponseHandler.swift in Sources */,
+				8ADF28B51303B381B5BADF71 /* ResponseAdapter.swift in Sources */,
+				DBB6BA7F5BA4F6525A350D22 /* RevealOperation.swift in Sources */,
+				A28CACC9D1FF82076A876DEE /* RightMichelsonParameter.swift in Sources */,
+				5176340FF8C190A4F793CDBB /* RunOperationRPC.swift in Sources */,
+				CD09D6ADC165E072F1941888 /* SignedOperationPayload.swift in Sources */,
+				8BE28CF8A5B3B2FD3C2D3781 /* SignedProtocolOperationPayload.swift in Sources */,
+				6A010379E6D6E1574A25E439 /* SigningService.swift in Sources */,
+				29E4A4AC683B33EFF8D6E0AE /* SimulationResult.swift in Sources */,
+				ADF7981B00CA77B702135F4F /* SimulationResultResponseAdapter.swift in Sources */,
+				246A505D04D6DD01AE3AE22F /* SimulationService.swift in Sources */,
+				053802B930B6B511932F2912 /* SomeMichelsonParameter.swift in Sources */,
+				20E9FCE054F634DB3EBE0352 /* StringMichelsonParameter.swift in Sources */,
+				D197ECDB0CE8D9806CA2DF33 /* StringResponseAdapter.swift in Sources */,
+				8A8A0C3FA8BB4D7D06B3BC41 /* Tez.swift in Sources */,
+				B00C58996BCA758752DD3B17 /* TezResponseAdapter.swift in Sources */,
+				C6C549A79623A9E2FD3D418E /* TezosKitError.swift in Sources */,
+				EA7CAAC03CEEC69CF5828734 /* TezosNodeClient+Promises.swift in Sources */,
+				86A23698EB0F1A7C654EA5FE /* TezosNodeClient.swift in Sources */,
+				D7BE1B36BA48E3EF78E8D88A /* TezosProtocol.swift in Sources */,
 				DB9D8A24F4E1BADBC532528E /* TokenContractClient.swift in Sources */,
-				AD7E61D1390EADE4288EBD6B /* Transaction.swift in Sources */,
-				4074E55E8D9F1A537FC937C5 /* TransactionOperation.swift in Sources */,
-				1D64CE5FEE90429D1FA3FADE /* TransactionsResponseAdapter.swift in Sources */,
-				255811A1BA8B43F6789C5293 /* UnitMichelsonParameter.swift in Sources */,
-				7CAD6087AFD81CC0FB00ACDE /* Wallet.swift in Sources */,
+				7AC9104107B7C65E0157CDAA /* Transaction.swift in Sources */,
+				B995FA190438FAC10CCCF28B /* TransactionOperation.swift in Sources */,
+				C7EC814C5823F266A4D6E3CF /* TransactionsResponseAdapter.swift in Sources */,
+				2B6489B6FC91E02E2474922C /* UnitMichelsonParameter.swift in Sources */,
+				2EA1145A13E79EA9F466EE0B /* Wallet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1703,107 +1791,107 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BE0C2E109FA99CA957F9CA63 /* AbstractMichelsonParameter.swift in Sources */,
-				AABB5CBBD979089DBAA793E8 /* AbstractOperation.swift in Sources */,
-				EE04960F9E50C9CB360B702F /* AbstractResponseAdapter.swift in Sources */,
-				DD9243045CC8CF3BEF0D4D72 /* Address.swift in Sources */,
-				289A83463CB9F040AB5FD071 /* BoolMichelsonParameter.swift in Sources */,
-				2EC3069A36FD23F3F32DC012 /* BytesMichelsonParameter.swift in Sources */,
+				903F786504865D80F76138B1 /* AbstractMichelsonParameter.swift in Sources */,
+				BF8368AEC93713FD0257CB2A /* AbstractOperation.swift in Sources */,
+				DE76843D18B4E20B091CFE2F /* AbstractResponseAdapter.swift in Sources */,
+				B03C7F8E33843942E97FCF88 /* Address.swift in Sources */,
+				E15E9B606007A7798D79926D /* BoolMichelsonParameter.swift in Sources */,
+				D7480678E5E575974B3692D7 /* BytesMichelsonParameter.swift in Sources */,
 				4914D80B62C56254DE5FBAC5 /* CodingUtil.swift in Sources */,
-				4E8E479655D27E3D722C68C3 /* ConseilClient+Promises.swift in Sources */,
+				64F80C86597E217AD2DEC700 /* ConseilClient+Promises.swift in Sources */,
 				E07DF9AE68C9FA30B47CA36C /* ConseilClient.swift in Sources */,
-				30DB919CF9D288E7FC110786 /* ConseilEntity.swift in Sources */,
-				129605BCC7AC042FE0DED2C0 /* ConseilNetwork.swift in Sources */,
-				B0E88B45AE7601D8A7C71267 /* ConseilPlatform.swift in Sources */,
-				8308A1E55F8BAD7EF8DDD13C /* ConseilQuery.swift in Sources */,
-				1CFE00B1E75656A8381551E8 /* ConseilQueryRPC.swift in Sources */,
-				437BF161917064D43BAE2EC5 /* DefaultFeeProvider.swift in Sources */,
-				AC65C3E0276EFBAB0AAC1F3F /* DelegationOperation.swift in Sources */,
+				1283CBD6F35544031013F520 /* ConseilEntity.swift in Sources */,
+				99EF9D9DD18902B98C5B2739 /* ConseilNetwork.swift in Sources */,
+				96B8D6BD4B20067EA9F462E7 /* ConseilPlatform.swift in Sources */,
+				E0959E31A8070943401A504B /* ConseilQuery.swift in Sources */,
+				8B2EA0D1375841337C15C2E1 /* ConseilQueryRPC.swift in Sources */,
+				1ED78FABDBE72F7DCB09474C /* DefaultFeeProvider.swift in Sources */,
+				8AA7945D4413BEEE0DD45E38 /* DelegationOperation.swift in Sources */,
 				B994572ABA098EEB4461FF25 /* DexterExchangeClient.swift in Sources */,
-				DC35FF69DF2F985AB7D8F2E7 /* FeeEstimator.swift in Sources */,
-				ED01B7FBB425A12A653B58DE /* ForgeOperationRPC.swift in Sources */,
-				A16AB8A466D6E16DBEBAEC05 /* ForgingPolicy.swift in Sources */,
-				350917ED569642CFB0290705 /* ForgingService.swift in Sources */,
-				6B2235B0F121E7BF9D10F839 /* GasLimitPolicy.swift in Sources */,
-				25410001FD50D214D5503CD0 /* GetAddressBalanceRPC.swift in Sources */,
-				599101D7C07D1947A453A96E /* GetAddressCounterRPC.swift in Sources */,
-				8CEEEE67BD78AE6796BB1B40 /* GetAddressDelegateRPC.swift in Sources */,
-				DC5715F6556341DE84AF0821 /* GetAddressManagerKeyRPC.swift in Sources */,
-				18EAEFA5541374412B3B4BA0 /* GetBallotsListRPC.swift in Sources */,
-				6A47C111B524E972AFB13429 /* GetBallotsRPC.swift in Sources */,
-				307771AC3EEB8B3EC9B6FB9F /* GetBigMapValueRPC.swift in Sources */,
-				249C7B3773262E954704338D /* GetChainHeadHashRPC.swift in Sources */,
-				58069C1F41C671CAAA8A1517 /* GetChainHeadRPC.swift in Sources */,
-				4B9A89D609ED62D5386EEE76 /* GetContractStorageRPC.swift in Sources */,
-				530D2848C9DDDAFCF350311F /* GetCurrentPeriodKindRPC.swift in Sources */,
-				112C531B1C24B1F194B9A97A /* GetExpectedQuorumRPC.swift in Sources */,
-				F3D701E5F127354344EEC7D5 /* GetOriginatedAccountsRPC.swift in Sources */,
-				775151EF78905D8F766556FB /* GetOriginatedContractsRPC.swift in Sources */,
-				F57C49A9619FC62F796AB03B /* GetProposalUnderEvaluationRPC.swift in Sources */,
-				DD36580D944333AC73129E1F /* GetProposalsListRPC.swift in Sources */,
-				461CAA4EB8501EA579D7205E /* GetReceivedTransactions.RPC.swift in Sources */,
-				97EAC0F9BFF327EB8B716452 /* GetSentTransactionsRPC.swift in Sources */,
-				45172B4BB09294806142D0B3 /* GetVotingDelegateRightsRPC.swift in Sources */,
-				9B0BD8D2A6B8765CB3AA92BD /* Header.swift in Sources */,
-				7AD56823491D043EA4175D1E /* Hex.swift in Sources */,
-				2CEA5ABD962A5EF2932B7602 /* InjectOperationRPC.swift in Sources */,
-				F6115CFFAB366B06EA61F582 /* InjectionService.swift in Sources */,
-				EFA3BD08DF624F7F7CC0E8AE /* IntMichelsonParameter.swift in Sources */,
-				AEAD53A2EEC5B56BB0C0B594 /* IntegerResponseAdapter.swift in Sources */,
-				AB1BEEC2FDC0BC2FC0233EAF /* JSONArrayResponseAdapter.swift in Sources */,
-				D191E0B37503B0286308DB36 /* JSONDictionaryResponseAdapter.swift in Sources */,
+				B3EC358C389D30BCBEE9B261 /* FeeEstimator.swift in Sources */,
+				F5010FF130B65BA032BA1C31 /* ForgeOperationRPC.swift in Sources */,
+				AB844D81BBE08DCFBD9FFF79 /* ForgingPolicy.swift in Sources */,
+				68EE902B48CF6D7D19AC7E67 /* ForgingService.swift in Sources */,
+				83A3CE6EDD434DE0657A3E39 /* GasLimitPolicy.swift in Sources */,
+				B0AD205420E9186FFBDF591A /* GetAddressBalanceRPC.swift in Sources */,
+				369AFABBC4DC7B34F4122FE7 /* GetAddressCounterRPC.swift in Sources */,
+				1A0E6F1CE869DB4A7C0D1C18 /* GetAddressDelegateRPC.swift in Sources */,
+				565974251F53ED2304F67976 /* GetAddressManagerKeyRPC.swift in Sources */,
+				E99BFF3E63A3086672E2E46D /* GetBallotsListRPC.swift in Sources */,
+				21DFB6D5F1C38A65473294A4 /* GetBallotsRPC.swift in Sources */,
+				BCE3F98F723E8ED5400723A1 /* GetBigMapValueRPC.swift in Sources */,
+				C59529A854409FB4806D2369 /* GetChainHeadHashRPC.swift in Sources */,
+				2699AF538FEBA53B91818459 /* GetChainHeadRPC.swift in Sources */,
+				77A465AF8459D646E26EDDF4 /* GetContractStorageRPC.swift in Sources */,
+				730FC94BF17634F7B0A065C0 /* GetCurrentPeriodKindRPC.swift in Sources */,
+				8756D5F4B281D22404F1A645 /* GetExpectedQuorumRPC.swift in Sources */,
+				DBFC5E6F2589F05F86749E79 /* GetOriginatedAccountsRPC.swift in Sources */,
+				59F27929724F9EF92946A3FC /* GetOriginatedContractsRPC.swift in Sources */,
+				DB6EA6FF18BEC9B88F56F40D /* GetProposalUnderEvaluationRPC.swift in Sources */,
+				88940D2D624897654210349C /* GetProposalsListRPC.swift in Sources */,
+				81E9D372DFF93EDC78B4A69A /* GetReceivedTransactions.RPC.swift in Sources */,
+				77CF4AAA059852274EECC261 /* GetSentTransactionsRPC.swift in Sources */,
+				5784F09DB5EC30B20CA0F97C /* GetVotingDelegateRightsRPC.swift in Sources */,
+				182FFFF06C61C8B6624FFAF9 /* Header.swift in Sources */,
+				5F860D6BBCAFFF96C507623B /* Hex.swift in Sources */,
+				E565D4EC8A4CCF33E6DBB8FB /* InjectOperationRPC.swift in Sources */,
+				768EC7127649F743CADF5485 /* InjectionService.swift in Sources */,
+				F4103197E94000D5141C3316 /* IntMichelsonParameter.swift in Sources */,
+				3F5EE99A632A748BBB6D0FE4 /* IntegerResponseAdapter.swift in Sources */,
+				D98B97305EDA7C6CDEEB8533 /* JSONArrayResponseAdapter.swift in Sources */,
+				0B817D8CE75D689CD87178C1 /* JSONDictionaryResponseAdapter.swift in Sources */,
 				083E6F479F724D868A0513C0 /* JSONUtils.swift in Sources */,
-				04E7EC6DACED48AB20774FDB /* LeftMichelsonParameter.swift in Sources */,
-				2D05A19038C29F31FC2A7B2A /* MichelsonAnnotation.swift in Sources */,
-				2537CB1115383A24297244EF /* MichelsonComparable.swift in Sources */,
-				98ED221ABABD2E1291C9362F /* MichelsonParameter.swift in Sources */,
+				B1E5191F0BB57EF3A72555FC /* LeftMichelsonParameter.swift in Sources */,
+				5762636B9F6E606FCF4E6981 /* MichelsonAnnotation.swift in Sources */,
+				8DB6E3EE6F04C2FF16A37338 /* MichelsonComparable.swift in Sources */,
+				7B0AFC2B03A527B407CD802C /* MichelsonParameter.swift in Sources */,
 				E05C6F3D3223E979E5DCA5C2 /* MnemonicUtil.swift in Sources */,
-				FFD14B38AC94C4085259CC1B /* NetworkClient+Promises.swift in Sources */,
-				1EBB5724B144B638D36DE81F /* NetworkClient.swift in Sources */,
-				61458E0CABF9E7287F7EB451 /* NoneMichelsonParameter.swift in Sources */,
-				71B9042ABE47B85C295BF8DF /* Operation.swift in Sources */,
-				69A55F43BE2B14F6B5215FC6 /* OperationFactory.swift in Sources */,
-				0398E107F5198C1557D9F02F /* OperationFeePolicy.swift in Sources */,
-				557704861BEEC380E6EE45B4 /* OperationFees.swift in Sources */,
-				4D43A79A774C271765314A72 /* OperationKind.swift in Sources */,
-				C62B123372ED5FC4C57F9473 /* OperationMetadata.swift in Sources */,
-				BB3E4EB39F9C57319B35C31C /* OperationMetadataProvider.swift in Sources */,
-				A222B28FC706D6619258D151 /* OperationPayload.swift in Sources */,
-				8165DE8F772C1AE0A7E66BC3 /* OperationPayloadFactory.swift in Sources */,
-				850FA2C5B3942A9E976BFBB7 /* OperationWithCounter.swift in Sources */,
-				7E5F52B8661857E80054650D /* PairMichelsonParameter.swift in Sources */,
-				3D46A73EE4F6CC255795FA65 /* PeriodKind.swift in Sources */,
-				0A7516411990C82E2B7F45CC /* PeriodKindResponseAdapter.swift in Sources */,
-				5C38482F3CF82120DFC54025 /* PreapplicationService.swift in Sources */,
-				D52008AE9352DF041114112E /* PreapplyOperationRPC.swift in Sources */,
-				EB503183CFD54E89B2B9570A /* PublicKey.swift in Sources */,
-				C13CD3FA76C8751C518ABBBD /* RPC.swift in Sources */,
-				2875D4D8D3B30CE41F76EA84 /* RPCResponseHandler.swift in Sources */,
-				8648DF0DE1A1F5B78171CB3B /* ResponseAdapter.swift in Sources */,
-				3E5182800DAD57ABCD180966 /* RevealOperation.swift in Sources */,
-				75239C4752AB9BD7F7876662 /* RightMichelsonParameter.swift in Sources */,
-				BE1CB24218F8167326C5EAE0 /* RunOperationRPC.swift in Sources */,
-				37000C76751363703B9438BB /* SignedOperationPayload.swift in Sources */,
-				598E95267D758C5779D41C2C /* SignedProtocolOperationPayload.swift in Sources */,
-				B83F0040C05754C876246BC0 /* SigningService.swift in Sources */,
-				D2CF73123947C4E3142DD149 /* SimulationResult.swift in Sources */,
-				A7B734AB8EF2AB2C2B6E49F2 /* SimulationResultResponseAdapter.swift in Sources */,
-				F72C34BD3C6F7F74438467C4 /* SimulationService.swift in Sources */,
-				C362525493F2B9A0927CB178 /* SomeMichelsonParameter.swift in Sources */,
-				9D47CE7663A9A3EA6737E233 /* StringMichelsonParameter.swift in Sources */,
-				6CF256A926954581A0CE454A /* StringResponseAdapter.swift in Sources */,
-				01F8923B93419159E3CBE612 /* Tez.swift in Sources */,
-				61802B4AD8A464BAC5E9237E /* TezResponseAdapter.swift in Sources */,
-				E001A484C34BA6EDB0CD0EBF /* TezosKitError.swift in Sources */,
-				C2A770578B6D88B232AE9EA6 /* TezosNodeClient+Promises.swift in Sources */,
-				14FAE84BC3BFEBB6379D6A7E /* TezosNodeClient.swift in Sources */,
-				387EDFCFEC4190BB903B916D /* TezosProtocol.swift in Sources */,
+				E022CE8D061446BAB1DEF80F /* NetworkClient+Promises.swift in Sources */,
+				76E015C816A9797BEA99C3D1 /* NetworkClient.swift in Sources */,
+				8B8CA3EF54C673DA42012EA7 /* NoneMichelsonParameter.swift in Sources */,
+				F0BB964AA315DE1D5FCB89DF /* Operation.swift in Sources */,
+				150BC04519380FB34ABE25AF /* OperationFactory.swift in Sources */,
+				09EDCDEF232C8F10CADD8ACD /* OperationFeePolicy.swift in Sources */,
+				F4F64ABB93F7DEDF78BFBB6F /* OperationFees.swift in Sources */,
+				70CA92EE6BB35E2898853956 /* OperationKind.swift in Sources */,
+				91A50FD1A526067E9A12F919 /* OperationMetadata.swift in Sources */,
+				6ADF54D797E8287A5DD92EC5 /* OperationMetadataProvider.swift in Sources */,
+				B481FCFB6820FB7C37019455 /* OperationPayload.swift in Sources */,
+				F20D1C720BE42B84FF5C3F60 /* OperationPayloadFactory.swift in Sources */,
+				9C490216EE45DD3B2D5FA043 /* OperationWithCounter.swift in Sources */,
+				84835281C8BB752513193EC6 /* PairMichelsonParameter.swift in Sources */,
+				C35BAE30B5D78DD325FFA296 /* PeriodKind.swift in Sources */,
+				619E6BD3481626F8DA9E6FA2 /* PeriodKindResponseAdapter.swift in Sources */,
+				3837CAC485DCEEA626A0602E /* PreapplicationService.swift in Sources */,
+				232A22C322ECB499CE1ABB97 /* PreapplyOperationRPC.swift in Sources */,
+				72E412B5F9680EE29264A648 /* PublicKey.swift in Sources */,
+				003826423B0CED390C5BFF08 /* RPC.swift in Sources */,
+				D0504B3FFA0DF83B7DE3A235 /* RPCResponseHandler.swift in Sources */,
+				123CA667757617121345656F /* ResponseAdapter.swift in Sources */,
+				EB8DB4F131248748EB318F10 /* RevealOperation.swift in Sources */,
+				247E267F324622195781C7FC /* RightMichelsonParameter.swift in Sources */,
+				C5A5A45C65BF1CFAC428C422 /* RunOperationRPC.swift in Sources */,
+				8F5F5CAA8F8726A3391FB576 /* SignedOperationPayload.swift in Sources */,
+				AE83DAF69E3ADD93C33F0B44 /* SignedProtocolOperationPayload.swift in Sources */,
+				3D0DFC6B5FED520A51FFA5ED /* SigningService.swift in Sources */,
+				CAC10984218AF43F7C858A7C /* SimulationResult.swift in Sources */,
+				EF0F55C1C1ABD3474DADDF52 /* SimulationResultResponseAdapter.swift in Sources */,
+				9B3002D8742780ABC34C5C10 /* SimulationService.swift in Sources */,
+				4DA4C7C8FA36B8D9C7739E5A /* SomeMichelsonParameter.swift in Sources */,
+				B511E62F850E8E2F3BD41094 /* StringMichelsonParameter.swift in Sources */,
+				B2FF44BEDF48FEE044D2AC91 /* StringResponseAdapter.swift in Sources */,
+				E65D8132F4164B73EF0B68DC /* Tez.swift in Sources */,
+				4810379C933F3041C8193B3E /* TezResponseAdapter.swift in Sources */,
+				4EE95B692BE0F6AFF3B9AE13 /* TezosKitError.swift in Sources */,
+				4F2F78B301A1CE1C55EE77BA /* TezosNodeClient+Promises.swift in Sources */,
+				5921B5ED76C2A0C0C67E36DA /* TezosNodeClient.swift in Sources */,
+				858F078119CB4C2CD735E34D /* TezosProtocol.swift in Sources */,
 				6AC4FC819BE657D545D58D65 /* TokenContractClient.swift in Sources */,
-				15E9CA64413A4EB306275585 /* Transaction.swift in Sources */,
-				7E2938740F4A7E993A9C048E /* TransactionOperation.swift in Sources */,
-				3BE23B5036B78060364F4C23 /* TransactionsResponseAdapter.swift in Sources */,
-				F9DFC2AA466107B108D0E68E /* UnitMichelsonParameter.swift in Sources */,
-				8E9911DADF5C9528BB5D46BE /* Wallet.swift in Sources */,
+				9772DD096F27A43644A5BE4B /* Transaction.swift in Sources */,
+				108B419FFDA7CF0729F362A8 /* TransactionOperation.swift in Sources */,
+				71E5791297A5DAE0D0D5C9C6 /* TransactionsResponseAdapter.swift in Sources */,
+				775E7DBBE39DCB0644DF5E42 /* UnitMichelsonParameter.swift in Sources */,
+				892E99DE1CF34B1762EF4EF1 /* Wallet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TezosKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/TezosKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/TezosKit/TezosNode/Models/OperationMetadata.swift
+++ b/TezosKit/TezosNode/Models/OperationMetadata.swift
@@ -5,6 +5,9 @@ import Foundation
 /// A lightweight property bag containing data about the current chain state in order to forge / preapply / inject
 /// operations on the Tezos blockchain.
 public struct OperationMetadata {
+  /// The ID of the chain being operated on.
+  public let chainID: String
+
   /// The hash of the head of the chain being operated on.
   public let branch: String
 


### PR DESCRIPTION
In the Babylon protocol, some RPCs require specifying a `chainID` when performing operations. This PR sets up fixes for those RPCs by adding this field to `OperationMetadata` and retrieving it inside of `OperationMetaDataProvider`