### PR TITLE
[Babylon] Separate `SmartContractInvocationOperation` from `TransactionOperation`

### DIFF
--- a/Tests/UnitTests/TezosKit/SmartContractInvocationOperationTest.swift
+++ b/Tests/UnitTests/TezosKit/SmartContractInvocationOperationTest.swift
@@ -1,0 +1,58 @@
+// Copyright Keefer Taylor, 2020
+
+@testable import TezosKit
+import XCTest
+
+// swiftlint:disable force_cast
+
+class SmartContractInvocationOperationTest: XCTestCase {
+  let destination = "tz1def"
+  let balance = Tez(3.50)
+  public func testDictionaryRepresentationWithParameter() {
+    let parameter = LeftMichelsonParameter(arg: IntMichelsonParameter(int: 42))
+
+    let operation = OperationFactory.testFactory.smartContractInvocationOperation(
+      amount: balance,
+      parameter: parameter,
+      source: .testAddress,
+      destination: .testDestinationAddress,
+      operationFeePolicy: .default,
+      signatureProvider: FakeSignatureProvider.testSignatureProvider
+    )!
+    let dictionary = operation.dictionaryRepresentation
+
+    // Verify parameter is as expected.
+    let parametersDictionary = dictionary[SmartContractInvocationOperation.JSON.Keys.parameters] as! [String: Any]
+    let serializedParameter =
+      JSONUtils.jsonString(for: parametersDictionary[SmartContractInvocationOperation.JSON.Keys.value] as! [String: Any])
+    let serializedExpected = JSONUtils.jsonString(for: parameter.networkRepresentation)
+    XCTAssertEqual(serializedParameter, serializedExpected)
+
+    // Verify entrypoint is as expected.
+    let entrypoint = parametersDictionary[SmartContractInvocationOperation.JSON.Keys.entrypoint] as! String
+    XCTAssertEqual(entrypoint, SmartContractInvocationOperation.JSON.Values.default)
+  }
+
+  public func testDictionaryRepresentationWithoutParameter() {
+    let operation = OperationFactory.testFactory.smartContractInvocationOperation(
+      amount: balance,
+      parameter: nil,
+      source: .testAddress,
+      destination: .testDestinationAddress,
+      operationFeePolicy: .default,
+      signatureProvider: FakeSignatureProvider.testSignatureProvider
+    )!
+    let dictionary = operation.dictionaryRepresentation
+
+    // Verify parameter is as expected.
+    let expectedParameter = UnitMichelsonParameter()
+    let parametersDictionary = dictionary[SmartContractInvocationOperation.JSON.Keys.parameters] as! [String: Any]
+    let serializedParameter = JSONUtils.jsonString(for: parametersDictionary[SmartContractInvocationOperation.JSON.Keys.value] as! [String: Any])
+    let serializedExpected = JSONUtils.jsonString(for: expectedParameter.networkRepresentation)
+    XCTAssertEqual(serializedParameter, serializedExpected)
+
+    // Verify entrypoint is as expected.
+    let entrypoint = parametersDictionary[SmartContractInvocationOperation.JSON.Keys.entrypoint] as! String
+    XCTAssertEqual(entrypoint, SmartContractInvocationOperation.JSON.Values.default)
+  }
+}

--- a/Tests/UnitTests/TezosKit/TransactionOperationTest.swift
+++ b/Tests/UnitTests/TezosKit/TransactionOperationTest.swift
@@ -6,10 +6,8 @@ import XCTest
 // swiftlint:disable force_cast
 
 class TransactionOperationTest: XCTestCase {
-  let destination = "tz1def"
-  let balance = Tez(3.50)
-
   public func testTransation() {
+    let balance = Tez(3.50)
     let operation = OperationFactory.testFactory.transactionOperation(
       amount: balance,
       source: .testAddress,
@@ -27,35 +25,5 @@ class TransactionOperationTest: XCTestCase {
 
     XCTAssertNotNil(dictionary["amount"])
     XCTAssertEqual(dictionary["amount"] as? String, balance.rpcRepresentation)
-  }
-
-  public func testTransationWithParameter() {
-    let parameter = LeftMichelsonParameter(arg: IntMichelsonParameter(int: 42))
-
-    let operation = OperationFactory.testFactory.smartContractInvocationOperation(
-      amount: balance,
-      parameter: parameter,
-      source: .testAddress,
-      destination: .testDestinationAddress,
-      operationFeePolicy: .default,
-      signatureProvider: FakeSignatureProvider.testSignatureProvider
-    )!
-    let dictionary = operation.dictionaryRepresentation
-
-    XCTAssertNotNil(dictionary["source"])
-    XCTAssertEqual(dictionary["source"] as? String, .testAddress)
-
-    XCTAssertNotNil(dictionary["destination"])
-    XCTAssertEqual(dictionary["destination"] as? String, .testDestinationAddress)
-
-    XCTAssertNotNil(dictionary["amount"])
-    XCTAssertEqual(dictionary["amount"] as? String, balance.rpcRepresentation)
-
-    let parametersDictionary = dictionary["parameters"] as! [String: Any]
-
-    let serializedParameter = JSONUtils.jsonString(for: parametersDictionary["value"] as! [String: Any])
-    let serializedExpected = JSONUtils.jsonString(for: parameter.networkRepresentation)
-
-    XCTAssertEqual(serializedParameter, serializedExpected)
   }
 }

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		4CFF0C9367C70838D3C7E88A /* CodingUtilTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47259C26A53DB562B22F087B /* CodingUtilTest.swift */; };
 		4D5203CB5AE5F88C2F55ABF7 /* CodingUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2415E6BE21BBCACF5128B13 /* CodingUtil.swift */; };
 		4DA4C7C8FA36B8D9C7739E5A /* SomeMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB80D50511873CF9783361B4 /* SomeMichelsonParameter.swift */; };
+		4E031688EA7ADD80E84B9300 /* SmartContractInvocationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE79D36BAE8F2465D6231C8 /* SmartContractInvocationOperation.swift */; };
 		4EE95B692BE0F6AFF3B9AE13 /* TezosKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 754389C145F7AF7208CBBD41 /* TezosKitError.swift */; };
 		4F0AC7852283D8C563FBAA9A /* OperationKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D81337F4A5B2C502DB3D076 /* OperationKind.swift */; };
 		4F2F78B301A1CE1C55EE77BA /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6AA3CAB521F463866CFB96 /* TezosNodeClient+Promises.swift */; };
@@ -149,6 +150,7 @@
 		5B9C772D561E314CE6957CBD /* GetChainHeadRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4252DFDE63B35970A3B59A /* GetChainHeadRPCTest.swift */; };
 		5C243C48B85DBB99E58CE34C /* AbstractResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29024177105AD82662279805 /* AbstractResponseAdapter.swift */; };
 		5C9E6119D5B8F50A8C076024 /* GasLimitPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F867E1CE5F1920E101259B /* GasLimitPolicy.swift */; };
+		5CC8904745E267CA4AF77ABA /* SmartContractInvocationOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8938737BEDF3F8E643E42865 /* SmartContractInvocationOperationTest.swift */; };
 		5CEAF373227D96DD66C2E95E /* InjectionServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443F94AEAF2C38E5B751E7EC /* InjectionServiceTest.swift */; };
 		5F860D6BBCAFFF96C507623B /* Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6067C4058BC42C52B64AF93A /* Hex.swift */; };
 		603E6A402CDCC7CBD6F24BC4 /* PreapplyOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC385B9CD31989369391F0B6 /* PreapplyOperationRPCTest.swift */; };
@@ -217,6 +219,7 @@
 		871FE402420222A66F323F7B /* MichelsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2ED9478409396EF8CA5E053 /* MichelsonTests.swift */; };
 		8756D5F4B281D22404F1A645 /* GetExpectedQuorumRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E006B0AA63CD2D50D07762F /* GetExpectedQuorumRPC.swift */; };
 		88940D2D624897654210349C /* GetProposalsListRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = C714AAB4A35FE0C6B5BEB154 /* GetProposalsListRPC.swift */; };
+		88B60F36E3AEB38D180B5802 /* SmartContractInvocationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE79D36BAE8F2465D6231C8 /* SmartContractInvocationOperation.swift */; };
 		892E99DE1CF34B1762EF4EF1 /* Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C4387729ED2573C33E3320F /* Wallet.swift */; };
 		89385B570B73F859DD132068 /* MnemonicKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 61EDBE7577517E6ACF2498A2 /* MnemonicKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8A33807BC7E3F132F72A4F8E /* NetworkClientTest+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DF61B717DBD0486D2AADF2 /* NetworkClientTest+Promises.swift */; };
@@ -256,6 +259,7 @@
 		9B22F93D4284980497E94D9E /* TezosKitErrorCodesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4254B915770CD924FBBE9D /* TezosKitErrorCodesTest.swift */; };
 		9B3002D8742780ABC34C5C10 /* SimulationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BFF651BFE4E4A3E90313FA9 /* SimulationService.swift */; };
 		9C490216EE45DD3B2D5FA043 /* OperationWithCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04781056C289A009489C072C /* OperationWithCounter.swift */; };
+		9D76FFEA43D41606A08098FB /* SmartContractInvocationOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8938737BEDF3F8E643E42865 /* SmartContractInvocationOperationTest.swift */; };
 		9DBE484969D7E6B3A53C8EFC /* PeriodKindResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33048AAA1D1966A1A89E409F /* PeriodKindResponseAdapterTest.swift */; };
 		9DCFB0E5181C64B30B7C0260 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B1E1C9C5236B52B797EFA7 /* Address.swift */; };
 		9DF0E0967190DD6291844766 /* OperationFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB59AEAEB019E7B641B448B1 /* OperationFactory.swift */; };
@@ -633,6 +637,7 @@
 		8554205D6B899410689D280F /* ConseilPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilPlatform.swift; sourceTree = "<group>"; };
 		86A2630E0DE0D72091FD3AE5 /* TezosKitIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TezosKitIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		88F56EE382535F0A59A52E76 /* TezResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezResponseAdapterTest.swift; sourceTree = "<group>"; };
+		8938737BEDF3F8E643E42865 /* SmartContractInvocationOperationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartContractInvocationOperationTest.swift; sourceTree = "<group>"; };
 		8A00D85C90C2E12DDC02E709 /* TransactionsResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsResponseAdapter.swift; sourceTree = "<group>"; };
 		8A1D2B885A5A1D1477E020C5 /* GetAddressBalanceRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressBalanceRPCTest.swift; sourceTree = "<group>"; };
 		8AE8CAB1EBF88156948D30F4 /* TokenContractClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenContractClient.swift; sourceTree = "<group>"; };
@@ -649,6 +654,7 @@
 		9983FD251855D94BAF486306 /* JSONUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONUtilsTest.swift; sourceTree = "<group>"; };
 		9A02A5F41589CD0850ED45F8 /* RPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPC.swift; sourceTree = "<group>"; };
 		9A992D50CBFAFC7476FCD3D6 /* TezosKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TezosKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9BE79D36BAE8F2465D6231C8 /* SmartContractInvocationOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartContractInvocationOperation.swift; sourceTree = "<group>"; };
 		9C0C00172340567CB1919631 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9F6AA3CAB521F463866CFB96 /* TezosNodeClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeClient+Promises.swift"; sourceTree = "<group>"; };
 		A057E76CA636DDEE045ED59C /* OperationMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMetadataProvider.swift; sourceTree = "<group>"; };
@@ -818,6 +824,7 @@
 				3D81337F4A5B2C502DB3D076 /* OperationKind.swift */,
 				04781056C289A009489C072C /* OperationWithCounter.swift */,
 				9497DCBC4C3BE5334CF8BC59 /* RevealOperation.swift */,
+				9BE79D36BAE8F2465D6231C8 /* SmartContractInvocationOperation.swift */,
 				A84ECF4C95D1743641BEF321 /* TransactionOperation.swift */,
 			);
 			path = Operation;
@@ -897,6 +904,7 @@
 				21DD030C2ACB7856608B34BA /* SigningServiceTests.swift */,
 				FF7C3270399D4C501F334311 /* SimulationResultResponseAdapterTest.swift */,
 				E0B48169F083D2DAEB462840 /* SimulationServiceTest.swift */,
+				8938737BEDF3F8E643E42865 /* SmartContractInvocationOperationTest.swift */,
 				CE7B474664A9C0C8EA93EA08 /* StringResponseAdapterTest.swift */,
 				AF4254B915770CD924FBBE9D /* TezosKitErrorCodesTest.swift */,
 				A480E400F3C3D065639376F4 /* TezosNodeClientTests.swift */,
@@ -1555,6 +1563,7 @@
 				826CAAB671AEE759E1F7A80A /* SigningServiceTests.swift in Sources */,
 				FCFF1137D39FC8613661D401 /* SimulationResultResponseAdapterTest.swift in Sources */,
 				4B6C324D7B7F0D168A2AC30B /* SimulationServiceTest.swift in Sources */,
+				9D76FFEA43D41606A08098FB /* SmartContractInvocationOperationTest.swift in Sources */,
 				F7DA8FC104D17AEC891A61BE /* StringResponseAdapterTest.swift in Sources */,
 				BEFD63E317CD24603BFD7134 /* TestHelpers.swift in Sources */,
 				6EA2C05ED0589F4D707AA291 /* TestObjects.swift in Sources */,
@@ -1677,6 +1686,7 @@
 				29E4A4AC683B33EFF8D6E0AE /* SimulationResult.swift in Sources */,
 				ADF7981B00CA77B702135F4F /* SimulationResultResponseAdapter.swift in Sources */,
 				246A505D04D6DD01AE3AE22F /* SimulationService.swift in Sources */,
+				4E031688EA7ADD80E84B9300 /* SmartContractInvocationOperation.swift in Sources */,
 				053802B930B6B511932F2912 /* SomeMichelsonParameter.swift in Sources */,
 				20E9FCE054F634DB3EBE0352 /* StringMichelsonParameter.swift in Sources */,
 				D197ECDB0CE8D9806CA2DF33 /* StringResponseAdapter.swift in Sources */,
@@ -1769,6 +1779,7 @@
 				BF58AA3718890216B35F94D1 /* SigningServiceTests.swift in Sources */,
 				AD7BF60763ABCBEE5ECC7C6E /* SimulationResultResponseAdapterTest.swift in Sources */,
 				91A310B7A87C5B736F4F8F3D /* SimulationServiceTest.swift in Sources */,
+				5CC8904745E267CA4AF77ABA /* SmartContractInvocationOperationTest.swift in Sources */,
 				50D2C68AA4145527E3333F6F /* StringResponseAdapterTest.swift in Sources */,
 				344530B289ACAD25404E5452 /* TestHelpers.swift in Sources */,
 				381DBFEA8AB85D0A93AD40FE /* TestObjects.swift in Sources */,
@@ -1875,6 +1886,7 @@
 				CAC10984218AF43F7C858A7C /* SimulationResult.swift in Sources */,
 				EF0F55C1C1ABD3474DADDF52 /* SimulationResultResponseAdapter.swift in Sources */,
 				9B3002D8742780ABC34C5C10 /* SimulationService.swift in Sources */,
+				88B60F36E3AEB38D180B5802 /* SmartContractInvocationOperation.swift in Sources */,
 				4DA4C7C8FA36B8D9C7739E5A /* SomeMichelsonParameter.swift in Sources */,
 				B511E62F850E8E2F3BD41094 /* StringMichelsonParameter.swift in Sources */,
 				B2FF44BEDF48FEE044D2AC91 /* StringResponseAdapter.swift in Sources */,

--- a/TezosKit/TezosNode/Models/Operation/SmartContractInvocationOperation.swift
+++ b/TezosKit/TezosNode/Models/Operation/SmartContractInvocationOperation.swift
@@ -1,0 +1,62 @@
+// Copyright Keefer Taylor, 2020
+
+import Foundation
+
+/// An operation to invoke a smart contract.
+public class SmartContractInvocationOperation: TransactionOperation {
+  internal enum JSON {
+    public enum Keys {
+      public static let entrypoint = "entrypoint"
+      public static let parameters = "parameters"
+      public static let value = "value"
+    }
+    public enum Values {
+      public static let `default` = "default"
+    }
+  }
+
+  private let parameter: MichelsonParameter?
+
+  public override var dictionaryRepresentation: [String: Any] {
+    var operation = super.dictionaryRepresentation
+
+    let parameter = self.parameter ?? UnitMichelsonParameter()
+    let entrypoint = SmartContractInvocationOperation.JSON.Values.default
+
+    let parameters: [String: Any] = [
+      SmartContractInvocationOperation.JSON.Keys.entrypoint: entrypoint,
+      SmartContractInvocationOperation.JSON.Keys.value: parameter.networkRepresentation
+    ]
+    operation[SmartContractInvocationOperation.JSON.Keys.parameters] = parameters
+
+    return operation
+  }
+
+  /// - Parameters:
+  ///   - amount: The amount of XTZ to transact.
+  ///   - parameter: An optional parameter to include in the transaction if the call is being made to a smart contract.
+  ///   - from: The address that is sending the XTZ.
+  ///   - to: The address that is receiving the XTZ.
+  ///   - operationFees: OperationFees for the transaction.
+  public init(
+    amount: Tez,
+    parameter: MichelsonParameter? = nil,
+    source: Address,
+    destination: Address,
+    operationFees: OperationFees
+  ) {
+    self.parameter = parameter
+
+    super.init(amount: amount, source: source, destination: destination, operationFees: operationFees)
+  }
+
+  public override func mutableCopy(with zone: NSZone? = nil) -> Any {
+    return SmartContractInvocationOperation(
+      amount: amount,
+      parameter: parameter,
+      source: source,
+      destination: destination,
+      operationFees: operationFees
+    )
+  }
+}

--- a/TezosKit/TezosNode/Models/Operation/TransactionOperation.swift
+++ b/TezosKit/TezosNode/Models/Operation/TransactionOperation.swift
@@ -7,52 +7,35 @@ public class TransactionOperation: AbstractOperation {
   private enum JSON {
     public enum Keys {
       public static let amount = "amount"
-      public static let entrypoint = "entrypoint"
       public static let destination = "destination"
-      public static let parameters = "parameters"
       public static let value = "value"
-    }
-    public enum Values {
-      public static let `default` = "default"
     }
   }
 
-  private let amount: Tez
-  private let destination: Address
-  private let parameter: MichelsonParameter?
+  internal let amount: Tez
+  internal let destination: Address
 
   public override var dictionaryRepresentation: [String: Any] {
     var operation = super.dictionaryRepresentation
     operation[TransactionOperation.JSON.Keys.amount] = amount.rpcRepresentation
     operation[TransactionOperation.JSON.Keys.destination] = destination
 
-    if let parameter = self.parameter {
-      let parameters: [String: Any] = [
-        TransactionOperation.JSON.Keys.entrypoint: TransactionOperation.JSON.Values.default,
-        TransactionOperation.JSON.Keys.value: parameter.networkRepresentation
-      ]
-      operation[TransactionOperation.JSON.Keys.parameters] = parameters
-    }
-
     return operation
   }
 
   /// - Parameters:
   ///   - amount: The amount of XTZ to transact.
-  ///   - parameter: An optional parameter to include in the transaction if the call is being made to a smart contract.
   ///   - from: The address that is sending the XTZ.
   ///   - to: The address that is receiving the XTZ.
   ///   - operationFees: OperationFees for the transaction.
   public init(
     amount: Tez,
-    parameter: MichelsonParameter? = nil,
     source: Address,
     destination: Address,
     operationFees: OperationFees
   ) {
     self.amount = amount
     self.destination = destination
-    self.parameter = parameter
 
     super.init(source: source, kind: .transaction, operationFees: operationFees)
   }
@@ -60,7 +43,6 @@ public class TransactionOperation: AbstractOperation {
   public override func mutableCopy(with zone: NSZone? = nil) -> Any {
     return TransactionOperation(
       amount: amount,
-      parameter: parameter,
       source: source,
       destination: destination,
       operationFees: operationFees

--- a/TezosKit/TezosNode/Services/OperationFactory.swift
+++ b/TezosKit/TezosNode/Services/OperationFactory.swift
@@ -205,7 +205,7 @@ public class OperationFactory {
     operationFeePolicy: OperationFeePolicy,
     signatureProvider: SignatureProvider
   ) -> Operation? {
-    let operation = TransactionOperation(
+    let operation = SmartContractInvocationOperation(
       amount: amount,
       parameter: parameter,
       source: source,


### PR DESCRIPTION
Utilize inheritance to create a new model. 

This simplifies the logic necessary when adding support for custom entrypoints. 