### PR TITLE
[Babylon] Support for custom entrypoints

### DIFF
--- a/Extensions/PromiseKit/TezosNode/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNode/TezosNodeClient+Promises.swift
@@ -295,7 +295,8 @@ extension TezosNodeClient {
   /// - Parameters:
   ///   - contract: The smart contract to invoke.
   ///   - amount: The amount of Tez to transfer with the invocation. Default is 0.
-  ///   - parameter: An optional parameter to send to the smart contract. Default is none.
+  ///   - entrypoint: An optional entrypoint to use for the transaction. Default is nil.
+  ///   - parameter: An optional parameter to send to the smart contract. Default is nil.
   ///   - source: The address invoking the contract.
   ///   - operationFeePolicy: A policy to apply when determining operation fees. Default is default fees.
   ///   - operationFeePolicy: A policy to apply when determining operation fees.
@@ -303,6 +304,7 @@ extension TezosNodeClient {
   public func call(
     contract: Address,
     amount: Tez = Tez.zeroBalance,
+    entrypoint: String? = nil,
     parameter: MichelsonParameter? = nil,
     source: Address,
     signatureProvider: SignatureProvider,
@@ -311,6 +313,7 @@ extension TezosNodeClient {
     guard
       let smartContractInvocationOperation = operationFactory.smartContractInvocationOperation(
         amount: amount,
+        entrypoint: entrypoint,
         parameter: parameter,
         source: source,
         destination: contract,

--- a/Tests/UnitTests/TezosKit/SmartContractInvocationOperationTest.swift
+++ b/Tests/UnitTests/TezosKit/SmartContractInvocationOperationTest.swift
@@ -8,11 +8,12 @@ import XCTest
 class SmartContractInvocationOperationTest: XCTestCase {
   let destination = "tz1def"
   let balance = Tez(3.50)
-  public func testDictionaryRepresentationWithParameter() {
-    let parameter = LeftMichelsonParameter(arg: IntMichelsonParameter(int: 42))
+  let parameter = LeftMichelsonParameter(arg: IntMichelsonParameter(int: 42))
 
+  public func testDictionaryRepresentationWithParameter() {
     let operation = OperationFactory.testFactory.smartContractInvocationOperation(
       amount: balance,
+      entrypoint: nil,
       parameter: parameter,
       source: .testAddress,
       destination: .testDestinationAddress,
@@ -33,9 +34,36 @@ class SmartContractInvocationOperationTest: XCTestCase {
     XCTAssertEqual(entrypoint, SmartContractInvocationOperation.JSON.Values.default)
   }
 
+  public func testDictionaryRepresentationWithParameterAndCustomEntrypoint() {
+    let entrypoint = "TezosKit"
+
+    let operation = OperationFactory.testFactory.smartContractInvocationOperation(
+      amount: balance,
+      entrypoint: entrypoint,
+      parameter: parameter,
+      source: .testAddress,
+      destination: .testDestinationAddress,
+      operationFeePolicy: .default,
+      signatureProvider: FakeSignatureProvider.testSignatureProvider
+    )!
+    let dictionary = operation.dictionaryRepresentation
+
+    // Verify parameter is as expected.
+    let parametersDictionary = dictionary[SmartContractInvocationOperation.JSON.Keys.parameters] as! [String: Any]
+    let serializedParameter =
+      JSONUtils.jsonString(for: parametersDictionary[SmartContractInvocationOperation.JSON.Keys.value] as! [String: Any])
+    let serializedExpected = JSONUtils.jsonString(for: parameter.networkRepresentation)
+    XCTAssertEqual(serializedParameter, serializedExpected)
+
+    // Verify entrypoint is as expected.
+    let dictionaryEntrypoint = parametersDictionary[SmartContractInvocationOperation.JSON.Keys.entrypoint] as! String
+    XCTAssertEqual(dictionaryEntrypoint, entrypoint)
+  }
+
   public func testDictionaryRepresentationWithoutParameter() {
     let operation = OperationFactory.testFactory.smartContractInvocationOperation(
       amount: balance,
+      entrypoint: nil,
       parameter: nil,
       source: .testAddress,
       destination: .testDestinationAddress,
@@ -55,4 +83,5 @@ class SmartContractInvocationOperationTest: XCTestCase {
     let entrypoint = parametersDictionary[SmartContractInvocationOperation.JSON.Keys.entrypoint] as! String
     XCTAssertEqual(entrypoint, SmartContractInvocationOperation.JSON.Values.default)
   }
+
 }

--- a/TezosKit/TezosNode/Models/Operation/SmartContractInvocationOperation.swift
+++ b/TezosKit/TezosNode/Models/Operation/SmartContractInvocationOperation.swift
@@ -15,13 +15,14 @@ public class SmartContractInvocationOperation: TransactionOperation {
     }
   }
 
+  private let entrypoint: String?
   private let parameter: MichelsonParameter?
 
   public override var dictionaryRepresentation: [String: Any] {
     var operation = super.dictionaryRepresentation
 
     let parameter = self.parameter ?? UnitMichelsonParameter()
-    let entrypoint = SmartContractInvocationOperation.JSON.Values.default
+    let entrypoint = self.entrypoint ?? SmartContractInvocationOperation.JSON.Values.default
 
     let parameters: [String: Any] = [
       SmartContractInvocationOperation.JSON.Keys.entrypoint: entrypoint,
@@ -34,17 +35,20 @@ public class SmartContractInvocationOperation: TransactionOperation {
 
   /// - Parameters:
   ///   - amount: The amount of XTZ to transact.
-  ///   - parameter: An optional parameter to include in the transaction if the call is being made to a smart contract.
+  ///   - entrypoint: An optional entrypoint to use for the transaction. If nil, the default entry point is used.
+  ///   - parameter: An optional parameter to include in the transaction if the call is being made to a smart contract. If nil, the unit parameter is used.
   ///   - from: The address that is sending the XTZ.
   ///   - to: The address that is receiving the XTZ.
   ///   - operationFees: OperationFees for the transaction.
   public init(
     amount: Tez,
+    entrypoint: String? = nil,
     parameter: MichelsonParameter? = nil,
     source: Address,
     destination: Address,
     operationFees: OperationFees
   ) {
+    self.entrypoint = entrypoint
     self.parameter = parameter
 
     super.init(amount: amount, source: source, destination: destination, operationFees: operationFees)

--- a/TezosKit/TezosNode/Services/OperationFactory.swift
+++ b/TezosKit/TezosNode/Services/OperationFactory.swift
@@ -192,6 +192,7 @@ public class OperationFactory {
   /// - Parameters:
   ///   - contract: The smart contract to invoke.
   ///   - amount: The amount of Tez to transfer with the invocation.
+  ///   - entrypoint: An optional entrypoint to use for the transaction.
   ///   - parameter: An optional parameter to send to the smart contract.
   ///   - source: The address invoking the contract.
   ///   - signatureProvider: The object which will sign the operation.
@@ -199,6 +200,7 @@ public class OperationFactory {
   ///   - signatureProvider: A signature provider which can sign the operation.
   public func smartContractInvocationOperation(
     amount: Tez,
+    entrypoint: String?,
     parameter: MichelsonParameter?,
     source: Address,
     destination: Address,
@@ -207,6 +209,7 @@ public class OperationFactory {
   ) -> Operation? {
     let operation = SmartContractInvocationOperation(
       amount: amount,
+      entrypoint: entrypoint,
       parameter: parameter,
       source: source,
       destination: destination,

--- a/TezosKit/TezosNode/TezosNodeClient.swift
+++ b/TezosKit/TezosNode/TezosNodeClient.swift
@@ -393,6 +393,7 @@ public class TezosNodeClient {
   /// - Parameters:
   ///   - contract: The smart contract to invoke.
   ///   - amount: The amount of Tez to transfer with the invocation. Default is 0.
+  ///   - entrypoint: An optional entrypoint to use for the transaction. Default is nil.
   ///   - parameter: An optional parameter to send to the smart contract. Default is none.
   ///   - source: The address invoking the contract.
   ///   - signatureProvider: The object which will sign the operation.
@@ -401,6 +402,7 @@ public class TezosNodeClient {
   public func call(
     contract: Address,
     amount: Tez = Tez.zeroBalance,
+    entrypoint: String? = nil,
     parameter: MichelsonParameter? = nil,
     source: Address,
     signatureProvider: SignatureProvider,
@@ -410,6 +412,7 @@ public class TezosNodeClient {
     guard
       let smartContractInvocationOperation = operationFactory.smartContractInvocationOperation(
         amount: amount,
+        entrypoint: entrypoint,
         parameter: parameter,
         source: source,
         destination: contract,


### PR DESCRIPTION
Add support for custom entrypoints when invoking smart contracts.

Specifically: 
- Plumb through `entrypoint` parameter, defaulted to `nil`
- Default `nil` values to the `default` endpoint
- Add tests to verify entrypoints work as expected