### PR TITLE
[Babylon] Add Run Operation RPC

### DIFF
--- a/Extensions/PromiseKit/TezosNode/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNode/TezosNodeClient+Promises.swift
@@ -11,7 +11,7 @@ extension TezosNodeClient {
   /// Retrieve data about the chain head.
   public func getHead() -> Promise<[String: Any]> {
     let rpc = GetChainHeadRPC()
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve the balance of a given wallet.
@@ -22,7 +22,7 @@ extension TezosNodeClient {
   /// Retrieve the balance of a given address.
   public func getBalance(address: Address) -> Promise<Tez> {
     let rpc = GetAddressBalanceRPC(address: address)
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve the delegate of a given wallet.
@@ -33,67 +33,67 @@ extension TezosNodeClient {
   /// Retrieve the delegate of a given address.
   public func getDelegate(address: Address) -> Promise<String> {
     let rpc = GetDelegateRPC(address: address)
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve the hash of the block at the head of the chain.
   public func getHeadHash() -> Promise<String> {
     let rpc = GetChainHeadHashRPC()
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve the address counter for the given address.
   public func getAddressCounter(address: Address) -> Promise<Int> {
     let rpc = GetAddressCounterRPC(address: address)
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve the address manager key for the given address.
   public func getAddressManagerKey(address: Address) -> Promise<String> {
     let rpc = GetAddressManagerKeyRPC(address: address)
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve ballots cast so far during a voting period.
   public func getBallotsList() -> Promise<[[String: Any]]> {
     let rpc = GetBallotsListRPC()
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   ///Retrieve the expected quorum.
   public func getExpectedQuorum() -> Promise<Int> {
     let rpc = GetExpectedQuorumRPC()
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve the current period kind for voting.
   public func getCurrentPeriodKind() -> Promise<PeriodKind> {
     let rpc = GetCurrentPeriodKindRPC()
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve the sum of ballots cast so far during a voting period.
   public func getBallots() -> Promise<[String: Any]> {
     let rpc = GetBallotsRPC()
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve a list of proposals with number of supporters.
   public func getProposalsList() -> Promise<[[String: Any]]> {
     let rpc = GetProposalsListRPC()
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve the current proposal under evaluation.
   public func getProposalUnderEvaluation() -> Promise<String> {
     let rpc = GetProposalUnderEvaluationRPC()
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve a list of delegates with their voting weight, in number of rolls.
   public func getVotingDelegateRights() -> Promise<[[String: Any]]> {
     let rpc = GetVotingDelegateRightsRPC()
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Retrieve the storage of a smart contract.
@@ -104,7 +104,7 @@ extension TezosNodeClient {
     address: Address
     ) -> Promise<[String: Any]> {
     let rpc = GetContractStorageRPC(address: address)
-    return networkClient.send(rpc)
+    return self.run(rpc)
   }
 
   /// Inspect the value of a big map in a smart contract.
@@ -119,7 +119,15 @@ extension TezosNodeClient {
     type: MichelsonComparable
     ) -> Promise<[String: Any]> {
     let rpc = GetBigMapValueRPC(address: address, key: key, type: type)
-    return networkClient.send(rpc)
+    return self.run(rpc)
+  }
+
+  /// Run an arbitrary RPC.
+  ///
+  /// - Parameters:
+  ///   - rpc: The RPC to run.
+  public func run<T>(_ rpc: RPC<T>) -> Promise<T> {
+    networkClient.send(rpc)
   }
 
   // MARK: - Operations

--- a/Extensions/PromiseKit/TezosNode/TezosNodeClient+Promises.swift
+++ b/Extensions/PromiseKit/TezosNode/TezosNodeClient+Promises.swift
@@ -127,7 +127,7 @@ extension TezosNodeClient {
   /// - Parameters:
   ///   - rpc: The RPC to run.
   public func run<T>(_ rpc: RPC<T>) -> Promise<T> {
-    networkClient.send(rpc)
+    return networkClient.send(rpc)
   }
 
   // MARK: - Operations

--- a/TezosKit/TezosNode/TezosNodeClient.swift
+++ b/TezosKit/TezosNode/TezosNodeClient.swift
@@ -160,7 +160,7 @@ public class TezosNodeClient {
   /// Retrieve data about the chain head.
   public func getHead(completion: @escaping (Result<[String: Any], TezosKitError>) -> Void) {
     let rpc = GetChainHeadRPC()
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve the balance of a given wallet.
@@ -171,7 +171,7 @@ public class TezosNodeClient {
   /// Retrieve the balance of a given address.
   public func getBalance(address: Address, completion: @escaping (Result<Tez, TezosKitError>) -> Void) {
     let rpc = GetAddressBalanceRPC(address: address)
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve the delegate of a given wallet.
@@ -182,19 +182,19 @@ public class TezosNodeClient {
   /// Retrieve the delegate of a given address.
   public func getDelegate(address: Address, completion: @escaping (Result<String, TezosKitError>) -> Void) {
     let rpc = GetDelegateRPC(address: address)
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve the hash of the block at the head of the chain.
   public func getHeadHash(completion: @escaping (Result<String, TezosKitError>) -> Void) {
     let rpc = GetChainHeadHashRPC()
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve the address counter for the given address.
   public func getAddressCounter(address: Address, completion: @escaping (Result<Int, TezosKitError>) -> Void) {
     let rpc = GetAddressCounterRPC(address: address)
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve the address manager key for the given address.
@@ -203,49 +203,49 @@ public class TezosNodeClient {
     completion: @escaping (Result<String, TezosKitError>) -> Void
   ) {
     let rpc = GetAddressManagerKeyRPC(address: address)
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve ballots cast so far during a voting period.
   public func getBallotsList(completion: @escaping (Result<[[String: Any]], TezosKitError>) -> Void) {
     let rpc = GetBallotsListRPC()
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve the expected quorum.
   public func getExpectedQuorum(completion: @escaping (Result<Int, TezosKitError>) -> Void) {
     let rpc = GetExpectedQuorumRPC()
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve the current period kind for voting.
   public func getCurrentPeriodKind(completion: @escaping (Result<PeriodKind, TezosKitError>) -> Void) {
     let rpc = GetCurrentPeriodKindRPC()
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve the sum of ballots cast so far during a voting period.
   public func getBallots(completion: @escaping (Result<[String: Any], TezosKitError>) -> Void) {
     let rpc = GetBallotsRPC()
-    networkClient.send(rpc, completion: completion)
-  }
+    self.run(rpc, completion: completion)  }
 
   /// Retrieve a list of proposals with number of supporters.
   public func getProposalsList(completion: @escaping (Result<[[String: Any]], TezosKitError>) -> Void) {
     let rpc = GetProposalsListRPC()
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve the current proposal under evaluation.
   public func getProposalUnderEvaluation(completion: @escaping (Result<String, TezosKitError>) -> Void) {
     let rpc = GetProposalUnderEvaluationRPC()
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve a list of delegates with their voting weight, in number of rolls.
   public func getVotingDelegateRights(completion: @escaping (Result<[[String: Any]], TezosKitError>) -> Void) {
     let rpc = GetVotingDelegateRightsRPC()
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
+
   }
 
   /// Inspect the value of a big map in a smart contract.
@@ -262,7 +262,7 @@ public class TezosNodeClient {
     completion: @escaping (Result<[String: Any], TezosKitError>) -> Void
   ) {
     let rpc = GetBigMapValueRPC(address: address, key: key, type: type)
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
   }
 
   /// Retrieve the storage of a smart contract.
@@ -275,7 +275,16 @@ public class TezosNodeClient {
     completion: @escaping (Result<[String: Any], TezosKitError>) -> Void
     ) {
     let rpc = GetContractStorageRPC(address: address)
-    networkClient.send(rpc, completion: completion)
+    self.run(rpc, completion: completion)
+  }
+
+  /// Run an arbitrary RPC.
+  ///
+  /// - Parameters:
+  ///   - rpc: The RPC to run.
+  ///   - completion : A completion block which handles the results of the RPC
+  public func run<T>(_ rpc: RPC<T>, completion: @escaping (Result<T, TezosKitError>) -> Void) {
+    self.networkClient.send(rpc, completion: completion)
   }
 
   // MARK: - Operations


### PR DESCRIPTION
Add the ability for users to run arbitrary RPCs. 

This is useful for power users and also allows for piecemeal testing of internal RPCs which will support Babylon big maps.