### PR TITLE
add babylonnet as an option to the conseil client

### DIFF
--- a/TezosKit/Conseil/Models/ConseilNetwork.swift
+++ b/TezosKit/Conseil/Models/ConseilNetwork.swift
@@ -4,5 +4,6 @@
 public enum ConseilNetwork: String, CaseIterable {
   case zeronet
   case alphanet
+  case babylonnet
   case mainnet
 }


### PR DESCRIPTION
The dev instance of the conseil network is now using babylonnet: https://conseil-dev.cryptonomic-infra.tech/docs#/