### PR TITLE
Base Work to Support Secp256K1 Curves

### DIFF
--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -158,6 +158,8 @@
 		5C9E6119D5B8F50A8C076024 /* GasLimitPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F867E1CE5F1920E101259B /* GasLimitPolicy.swift */; };
 		5CC8904745E267CA4AF77ABA /* SmartContractInvocationOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8938737BEDF3F8E643E42865 /* SmartContractInvocationOperationTest.swift */; };
 		5CEAF373227D96DD66C2E95E /* InjectionServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 443F94AEAF2C38E5B751E7EC /* InjectionServiceTest.swift */; };
+		5D5758544F11E6220DBAACAE /* CryptoUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1932C926CE0A11BC0663D1A /* CryptoUtilTests.swift */; };
+		5DF495C1840691202415F040 /* CryptoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900C4EF29B323D36C58C403C /* CryptoUtils.swift */; };
 		5F860D6BBCAFFF96C507623B /* Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6067C4058BC42C52B64AF93A /* Hex.swift */; };
 		603E6A402CDCC7CBD6F24BC4 /* PreapplyOperationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC385B9CD31989369391F0B6 /* PreapplyOperationRPCTest.swift */; };
 		609CBA9E58941C450A963639 /* MichelsonComparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525C931C7CD120487B51DA9A /* MichelsonComparable.swift */; };
@@ -167,6 +169,7 @@
 		62903921C8ECC8722A4C546D /* MichelsonAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362C94B98BAA147AB9D080DC /* MichelsonAnnotationTests.swift */; };
 		62A5879D7602B510810B924D /* OperationWithCounterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 274E2A45E6EB2DCA9A6D1E3F /* OperationWithCounterTest.swift */; };
 		62C0718A0A00329A5232FF3A /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AFC77643CD2C374042E0B932 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6366827CD11DDB980E5B0638 /* CryptoUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1932C926CE0A11BC0663D1A /* CryptoUtilTests.swift */; };
 		64185B7D0E39391674A70F5A /* OperationPayloadFactoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFE3E8D18069FFC9F79BF11D /* OperationPayloadFactoryTest.swift */; };
 		649E1CC62E843A2E2282421F /* NetworkClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CD7E1718D9928582CA4984 /* NetworkClientTest.swift */; };
 		64F80C86597E217AD2DEC700 /* ConseilClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0922D1ADC86CC9907C3EEBA2 /* ConseilClient+Promises.swift */; };
@@ -205,6 +208,7 @@
 		7AC9104107B7C65E0157CDAA /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53D59AD9EA44F6B351A350F /* Transaction.swift */; };
 		7ADA70F21D418E673B3D1FC2 /* TezosCrypto.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 39FE75C2C5F5177A3F3C6752 /* TezosCrypto.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7B0AFC2B03A527B407CD802C /* MichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908CE3F01F463AD656302DFD /* MichelsonParameter.swift */; };
+		7B2A878C1C0A55D64B5A5247 /* CryptoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900C4EF29B323D36C58C403C /* CryptoUtils.swift */; };
 		7D7DE0D66FA04949CD3EBF56 /* MichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 908CE3F01F463AD656302DFD /* MichelsonParameter.swift */; };
 		7DBDD4E5B7E0D5672BDDA73E /* MnemonicKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD4B1012288DD6F90E8C78A /* MnemonicKit.framework */; };
 		7E28672FA338FA3D8E163026 /* ConseilQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB45514356C89019DB00E50 /* ConseilQuery.swift */; };
@@ -371,7 +375,6 @@
 		D3CCCC07096A97A328B93B13 /* RPCResponseHandlerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BD174BFAC4ED4214E582E4D /* RPCResponseHandlerTest.swift */; };
 		D3E2F1400C41E92F55451367 /* PreapplyOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B033280AD0AE71CF00F15555 /* PreapplyOperationRPC.swift */; };
 		D445EE1F54141ACD6014D443 /* MnemonicKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1DD4B1012288DD6F90E8C78A /* MnemonicKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D68CDB7A3978B2813A633AF3 /* TezosCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572AC3BBE65D10D59F8DCC89 /* TezosCryptoTests.swift */; };
 		D7480678E5E575974B3692D7 /* BytesMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3CEDF87CB74674EF5E2BB5 /* BytesMichelsonParameter.swift */; };
 		D7BE1B36BA48E3EF78E8D88A /* TezosProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B059E31F2A63807B325D4115 /* TezosProtocol.swift */; };
 		D7BF3E0BD873DA969B967580 /* TezosNodeIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7032899C34EC0CB096B9A57C /* TezosNodeIntegrationTests.swift */; };
@@ -401,7 +404,6 @@
 		E1BA99AD0B1A4AECDD2A8ADD /* DelegationOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35169AC0F795C07FA8AC1ED /* DelegationOperationTest.swift */; };
 		E26EA01A1CBE78934F1DB018 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4B3BE4BAECB893457A44FC1 /* TestHelpers.swift */; };
 		E2F309725BF25B205C05A6AE /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AC64BA50EF400CF4B90951AA /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E30F1A90FE03894C299E2A88 /* TezosCryptoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AF2EEB2DB071DCD75326C7 /* TezosCryptoUtils.swift */; };
 		E565D4EC8A4CCF33E6DBB8FB /* InjectOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2CD91AC2A1310E66E207E /* InjectOperationRPC.swift */; };
 		E5A68008EC346FFCD3D4E654 /* GetBigMapValueRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66310D79AAEC83514BB1F0F8 /* GetBigMapValueRPCTest.swift */; };
 		E65D8132F4164B73EF0B68DC /* Tez.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6EF4B87FBEBB73B166F339 /* Tez.swift */; };
@@ -432,10 +434,8 @@
 		F64A31F20AFD809EE41CCA02 /* OperationFactoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A33A07A0728F3091018D933 /* OperationFactoryTest.swift */; };
 		F67AA457A2052215F46D22C3 /* ConseilClientIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1968AE0A3A2B4DAD756FD72 /* ConseilClientIntegrationTests.swift */; };
 		F71BD51C6A8C3F5CB182AE41 /* PackDataPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510562653A6F7930885D3F55 /* PackDataPayload.swift */; };
-		F7395F51735385BFCA3635CA /* TezosCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572AC3BBE65D10D59F8DCC89 /* TezosCryptoTests.swift */; };
 		F7DA8FC104D17AEC891A61BE /* StringResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B474664A9C0C8EA93EA08 /* StringResponseAdapterTest.swift */; };
 		F808CE08290F42ED19C06B78 /* IntegerResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC964601A972639F6CEDDF75 /* IntegerResponseAdapterTest.swift */; };
-		F8FBA29C24F8B9550AFE234B /* TezosCryptoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AF2EEB2DB071DCD75326C7 /* TezosCryptoUtils.swift */; };
 		F9BE3DBB7109326574DD8821 /* GetBigMapValueRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0577D28D7A8761465FE76F9 /* GetBigMapValueRPC.swift */; };
 		FA69D591490F2E93C465A258 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC64BA50EF400CF4B90951AA /* CryptoSwift.framework */; };
 		FAFE54CF7E5E0BC0D60B460E /* PromiseKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 33A83E353521083164433924 /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -628,8 +628,6 @@
 		525C931C7CD120487B51DA9A /* MichelsonComparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonComparable.swift; sourceTree = "<group>"; };
 		53BA885B9E3E1F6BA3693A3F /* SignedProtocolOperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedProtocolOperationPayload.swift; sourceTree = "<group>"; };
 		55B2484FD06C8D95BB5ACDCC /* ConseilClientIntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConseilClientIntegrationTests+Promises.swift"; sourceTree = "<group>"; };
-		56AF2EEB2DB071DCD75326C7 /* TezosCryptoUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosCryptoUtils.swift; sourceTree = "<group>"; };
-		572AC3BBE65D10D59F8DCC89 /* TezosCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosCryptoTests.swift; sourceTree = "<group>"; };
 		588112F5BDBF5213EB952EF1 /* NoneMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoneMichelsonParameter.swift; sourceTree = "<group>"; };
 		5ADF6AC0E4147B4D778F38BB /* PackDataResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackDataResponseAdapterTest.swift; sourceTree = "<group>"; };
 		5BD174BFAC4ED4214E582E4D /* RPCResponseHandlerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RPCResponseHandlerTest.swift; sourceTree = "<group>"; };
@@ -679,6 +677,7 @@
 		8AE8CAB1EBF88156948D30F4 /* TokenContractClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenContractClient.swift; sourceTree = "<group>"; };
 		8F1D1F6B1DDF04EB174551D3 /* TestObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestObjects.swift; sourceTree = "<group>"; };
 		900000AC3F1E51ABDB97459A /* TezosNodeIntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TezosNodeIntegrationTests+Promises.swift"; sourceTree = "<group>"; };
+		900C4EF29B323D36C58C403C /* CryptoUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoUtils.swift; sourceTree = "<group>"; };
 		908CE3F01F463AD656302DFD /* MichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonParameter.swift; sourceTree = "<group>"; };
 		90D9A0CB32FB707D9BF32654 /* ResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseAdapter.swift; sourceTree = "<group>"; };
 		933679D90DA718BAE1ECF1ED /* GetCurrentPeriodKindRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCurrentPeriodKindRPC.swift; sourceTree = "<group>"; };
@@ -743,6 +742,7 @@
 		CF8BF4B1C7E42EB59D27150B /* GetAddressBalanceRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressBalanceRPC.swift; sourceTree = "<group>"; };
 		CFB45514356C89019DB00E50 /* ConseilQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilQuery.swift; sourceTree = "<group>"; };
 		D02267ED3BD3130460D19101 /* TezosCrypto.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = TezosCrypto.framework; sourceTree = "<group>"; };
+		D1932C926CE0A11BC0663D1A /* CryptoUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoUtilTests.swift; sourceTree = "<group>"; };
 		D2F15CD865BE921BF9DF8CC0 /* MichelsonAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonAnnotation.swift; sourceTree = "<group>"; };
 		D4CC2EFE37BC672A082A9F69 /* TezosKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TezosKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D650111C52C89A65467CC889 /* UnitMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitMichelsonParameter.swift; sourceTree = "<group>"; };
@@ -898,6 +898,7 @@
 				AA46CF630A8512DF758EB2E2 /* ConseilEntityTest.swift */,
 				63AB3DCEF101AC8B5CB3BEBD /* ConseilNetworkTest.swift */,
 				11EF1D7D0F6C1FC15B1F0600 /* ConseilPlatformTest.swift */,
+				D1932C926CE0A11BC0663D1A /* CryptoUtilTests.swift */,
 				B35169AC0F795C07FA8AC1ED /* DelegationOperationTest.swift */,
 				274BAF5E1A4B223F09042484 /* DexterExchangeClientTests.swift */,
 				1EC56B6DF6FF924206963D52 /* FeeEstimatorTest.swift */,
@@ -950,7 +951,6 @@
 				E0B48169F083D2DAEB462840 /* SimulationServiceTest.swift */,
 				8938737BEDF3F8E643E42865 /* SmartContractInvocationOperationTest.swift */,
 				CE7B474664A9C0C8EA93EA08 /* StringResponseAdapterTest.swift */,
-				572AC3BBE65D10D59F8DCC89 /* TezosCryptoTests.swift */,
 				AF4254B915770CD924FBBE9D /* TezosKitErrorCodesTest.swift */,
 				A480E400F3C3D065639376F4 /* TezosNodeClientTests.swift */,
 				88F56EE382535F0A59A52E76 /* TezResponseAdapterTest.swift */,
@@ -1046,13 +1046,13 @@
 			isa = PBXGroup;
 			children = (
 				E57EC805C27A406AF0C4B17E /* Base58+TezosCrypto.swift */,
+				900C4EF29B323D36C58C403C /* CryptoUtils.swift */,
 				0BB8C8A74A942774B715E706 /* EllipticalCurve.swift */,
 				0A77AE24F8BDC52A906F1A10 /* Prefixes.swift */,
 				D8DD132F238141B3A1D24CC3 /* PublicKey.swift */,
 				AB80BC8FA72641177E530F7E /* PublicKeyProtocol.swift */,
 				9EA478BD897E8082B638E6E0 /* SecretKey.swift */,
 				8373F22F20972134DC7B3DC4 /* Sodium+TezosCrypto.swift */,
-				56AF2EEB2DB071DCD75326C7 /* TezosCryptoUtils.swift */,
 			);
 			path = Crypto;
 			sourceTree = "<group>";
@@ -1579,6 +1579,7 @@
 				3E56D8D9630D6F609A7888B1 /* ConseilEntityTest.swift in Sources */,
 				511F64E3E072BCC48A75B104 /* ConseilNetworkTest.swift in Sources */,
 				B36A567790DC7ED9A75FFDAB /* ConseilPlatformTest.swift in Sources */,
+				5D5758544F11E6220DBAACAE /* CryptoUtilTests.swift in Sources */,
 				E1BA99AD0B1A4AECDD2A8ADD /* DelegationOperationTest.swift in Sources */,
 				AA82E884F2075A30018067CC /* DexterExchangeClientTests.swift in Sources */,
 				91F7DB335A6358E36BD62134 /* FakeObjects.swift in Sources */,
@@ -1636,7 +1637,6 @@
 				6EA2C05ED0589F4D707AA291 /* TestObjects.swift in Sources */,
 				42942076138616B8E91C9280 /* TezResponseAdapterTest.swift in Sources */,
 				FEFBD0AE42D0285E2DBFAEDB /* TezTest.swift in Sources */,
-				F7395F51735385BFCA3635CA /* TezosCryptoTests.swift in Sources */,
 				3CC9387F30A2C0880378097A /* TezosKitErrorCodesTest.swift in Sources */,
 				59A2F834737A398C874C200B /* TezosNodeClientTests.swift in Sources */,
 				D351C031963368534FAEBC50 /* TokenContractClientTests.swift in Sources */,
@@ -1681,6 +1681,7 @@
 				B4CE5A171E1ED4CBA547A3BF /* ConseilPlatform.swift in Sources */,
 				7E28672FA338FA3D8E163026 /* ConseilQuery.swift in Sources */,
 				26BD1B449C1BDF0A34EB3424 /* ConseilQueryRPC.swift in Sources */,
+				7B2A878C1C0A55D64B5A5247 /* CryptoUtils.swift in Sources */,
 				EBB75619AA9E3C31007B00C1 /* DefaultFeeProvider.swift in Sources */,
 				99A8DDEC1498C877C4C5F662 /* DelegationOperation.swift in Sources */,
 				F26AA961D4B0EC32849B8C50 /* DexterExchangeClient.swift in Sources */,
@@ -1769,7 +1770,6 @@
 				D197ECDB0CE8D9806CA2DF33 /* StringResponseAdapter.swift in Sources */,
 				8A8A0C3FA8BB4D7D06B3BC41 /* Tez.swift in Sources */,
 				B00C58996BCA758752DD3B17 /* TezResponseAdapter.swift in Sources */,
-				F8FBA29C24F8B9550AFE234B /* TezosCryptoUtils.swift in Sources */,
 				C6C549A79623A9E2FD3D418E /* TezosKitError.swift in Sources */,
 				EA7CAAC03CEEC69CF5828734 /* TezosNodeClient+Promises.swift in Sources */,
 				86A23698EB0F1A7C654EA5FE /* TezosNodeClient.swift in Sources */,
@@ -1809,6 +1809,7 @@
 				F2EB65B5F6C112EC1BB42B12 /* ConseilEntityTest.swift in Sources */,
 				B8F8E590F5D535715B905D3C /* ConseilNetworkTest.swift in Sources */,
 				0B90CE79C85654F51E3D1E97 /* ConseilPlatformTest.swift in Sources */,
+				6366827CD11DDB980E5B0638 /* CryptoUtilTests.swift in Sources */,
 				A26BF0891BE26654AB683DF1 /* DelegationOperationTest.swift in Sources */,
 				A88030B456653F6A73CC5077 /* DexterExchangeClientTests.swift in Sources */,
 				5887D02AA393101D925EFE47 /* FakeObjects.swift in Sources */,
@@ -1866,7 +1867,6 @@
 				381DBFEA8AB85D0A93AD40FE /* TestObjects.swift in Sources */,
 				C6AAFF78C788015D767EB6B8 /* TezResponseAdapterTest.swift in Sources */,
 				127F92545866411A37E2563A /* TezTest.swift in Sources */,
-				D68CDB7A3978B2813A633AF3 /* TezosCryptoTests.swift in Sources */,
 				9B22F93D4284980497E94D9E /* TezosKitErrorCodesTest.swift in Sources */,
 				32144B5BCBA06B8114DF0F0D /* TezosNodeClientTests.swift in Sources */,
 				9832CCBED4906F7744DAF714 /* TokenContractClientTests.swift in Sources */,
@@ -1895,6 +1895,7 @@
 				96B8D6BD4B20067EA9F462E7 /* ConseilPlatform.swift in Sources */,
 				E0959E31A8070943401A504B /* ConseilQuery.swift in Sources */,
 				8B2EA0D1375841337C15C2E1 /* ConseilQueryRPC.swift in Sources */,
+				5DF495C1840691202415F040 /* CryptoUtils.swift in Sources */,
 				1ED78FABDBE72F7DCB09474C /* DefaultFeeProvider.swift in Sources */,
 				8AA7945D4413BEEE0DD45E38 /* DelegationOperation.swift in Sources */,
 				B994572ABA098EEB4461FF25 /* DexterExchangeClient.swift in Sources */,
@@ -1983,7 +1984,6 @@
 				B2FF44BEDF48FEE044D2AC91 /* StringResponseAdapter.swift in Sources */,
 				E65D8132F4164B73EF0B68DC /* Tez.swift in Sources */,
 				4810379C933F3041C8193B3E /* TezResponseAdapter.swift in Sources */,
-				E30F1A90FE03894C299E2A88 /* TezosCryptoUtils.swift in Sources */,
 				4EE95B692BE0F6AFF3B9AE13 /* TezosKitError.swift in Sources */,
 				4F2F78B301A1CE1C55EE77BA /* TezosNodeClient+Promises.swift in Sources */,
 				5921B5ED76C2A0C0C67E36DA /* TezosNodeClient.swift in Sources */,

--- a/TezosKit/Crypto/EllipticalCurve.swift
+++ b/TezosKit/Crypto/EllipticalCurve.swift
@@ -2,6 +2,8 @@
 
 import Foundation
 
+/// Elliptical curves that can be used in elliptical curve cryptographic operations.
 public enum EllipticalCurve {
   case ed25519
+  case secp256k1
 }


### PR DESCRIPTION
Implement placeholders which fail with fatal errors. 

This work preps the ability to support multiple address types (tz1, tz2, tz3) inside of TezosKit, including support for signing in places other than program memory (device keychain or secure enclave). 