### PR TITLE
Add Example App as Test Bed for Secure Enclave Work

### DIFF
--- a/Examples/SecureEnclave/Base.lproj/LaunchScreen.storyboard
+++ b/Examples/SecureEnclave/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/SecureEnclave/Base.lproj/Main.storyboard
+++ b/Examples/SecureEnclave/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/SecureEnclave/Enclave.entitlements
+++ b/Examples/SecureEnclave/Enclave.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.keefertaylor.Enclave</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/SecureEnclave/Enclave.entitlements
+++ b/Examples/SecureEnclave/Enclave.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.keefertaylor.Enclave</string>
+		<string>$(AppIdentifierPrefix)com.keefertaylor.TezosKit.SecureEnclave</string>
 	</array>
 </dict>
 </plist>

--- a/Examples/SecureEnclave/Info.plist
+++ b/Examples/SecureEnclave/Info.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Tezos HSM</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>NSFaceIDUsageDescription</key>
+	<string>This app uses Face ID to sign Tezos Transactions</string>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/SecureEnclave/SecureEnclaveAppDelegate.swift
+++ b/Examples/SecureEnclave/SecureEnclaveAppDelegate.swift
@@ -1,0 +1,45 @@
+//
+//  AppDelegate.swift
+//  Enclave
+//
+//  Created by Keefer Taylor on 5/1/19.
+//  Copyright © 2019 Keefer Taylor. All rights reserved.
+//
+import TezosKit
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+  var window: UIWindow?
+  var nc: TezosNodeClient?
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+    // Override point for customization after application launch.
+    return true
+  }
+
+  func applicationWillResignActive(_ application: UIApplication) {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+  }
+
+  func applicationDidEnterBackground(_ application: UIApplication) {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+  }
+
+  func applicationWillEnterForeground(_ application: UIApplication) {
+    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+  }
+
+  func applicationDidBecomeActive(_ application: UIApplication) {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+  }
+
+  func applicationWillTerminate(_ application: UIApplication) {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+  }
+
+}

--- a/Examples/SecureEnclave/ViewController.swift
+++ b/Examples/SecureEnclave/ViewController.swift
@@ -1,52 +1,33 @@
-//
-//  ViewController.swift
-//  Enclave
-//
-//  Created by Keefer Taylor on 5/1/19.
-//  Copyright © 2019 Keefer Taylor. All rights reserved.
-//
+// Copyright Keefer Taylor, 2020.
+
 import TezosKit
 import UIKit
 
-class BackgroundHighlightedButton: UIButton {
-  @IBInspectable var highlightedBackgroundColor: UIColor?
-  @IBInspectable var nonHighlightedBackgroundColor: UIColor?
-  override var isHighlighted: Bool {
-    get {
-      return super.isHighlighted
-    }
-    set {
-      if newValue {
-        self.backgroundColor = .blue
-      } else {
-        self.backgroundColor = .gray
-      }
-      super.isHighlighted = isHighlighted
-    }
-  }
-}
-
 class ViewController: UIViewController {
+  /// UI Components.
   public let titleLabel: UILabel = UILabel()
-
   public let generateKey: UIButton = BackgroundHighlightedButton()
   public let pkh: UILabel = UILabel()
   public let genKey: UILabel = UILabel()
   public let dest: UILabel = UILabel()
   public let destKey: UILabel = UILabel()
-
-  var nodeClient: TezosNodeClient?
-
   public let signTransaction: UIButton = BackgroundHighlightedButton()
   public let h = UILabel()
   public let hash2 = UILabel()
-
   public let open: UIButton = BackgroundHighlightedButton()
+
+  /// The wallet that we're interacting with.
+  var wallet: SignatureProvider?
+
+  /// The last operation hash received from TezosClient.
+  var opHash: String?
+
+  // MARK: - UIView
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
-//    title.setTitle("Tezos Secure Enclave Signing")
+    titleLabel.text = "Tezos Secure Enclave Signing"
     generateKey.setTitle("Generate Key", for: .normal)
     generateKey.frame = CGRect(x: 50, y: 200, width: 300, height: 50)
     generateKey.backgroundColor = .gray
@@ -83,45 +64,51 @@ class ViewController: UIViewController {
     hash2.frame = CGRect(x: 50, y: 570, width: 300, height: 20)
     self.view.addSubview(hash2)
 
-    open.setTitle("Open in TzScan", for: .normal)
+    open.setTitle("Open in Block Explorer", for: .normal)
     open.frame = CGRect(x: 50, y: 610, width: 300, height: 50)
     open.backgroundColor = .gray
     open.addTarget(self, action: #selector(openFn), for: .touchUpInside)
     self.view.addSubview(open)
   }
 
+  // MARK: - User Interaction
+
   @objc
   func generate() {
-    // TODO: Update this
-    // TODO: REcall key compression.
-    genKey.text = "tz3fq2juip9PQfxnQ5JTdwzEscdkVpWi2rTs"
-  }
+    let wallet = Wallet()
 
-  var opHash: String?
+    genKey.text = wallet?.address
+
+    self.wallet = wallet
+  }
 
   @objc
   func send() {
-//    let nodeURL = URL(string: "http://alphanet-node.tzscan.io:80")! // URL(string: "http://127.0.0.1:8732")!
-//    nodeClient = TezosNodeClient(remoteNodeURL: nodeURL)
-//
-//    let wallet = Wallet()!
-//    nodeClient!.send(
-//    amount: Tez("1")!, to: "tz1NpWrAyDL9k2Lmnyxcgr9xuJakbBxdq7FB", from: "tz3fq2juip9PQfxnQ5JTdwzEscdkVpWi2rTs", keys: wallet) { result in
-//      switch result {
-//      case .failure(let error):
-//        print("WRONG")
-//        print(error)
-//      case .success(let hash):
-//        self.opHash = hash
-//        self.hash2.text = hash
-//      }
-//    }
+    guard let wallet = self.wallet else {
+      return
+    }
+
+    let nodeURL = URL(string: "https://tezos-dev.cryptonomic-infra.tech")!
+    let nodeClient = TezosNodeClient(remoteNodeURL: nodeURL)
+    nodeClient.send(
+      amount: Tez("1")!,
+      to: "tz1NpWrAyDL9k2Lmnyxcgr9xuJakbBxdq7FB",
+      from: "x",
+      signatureProvider: wallet,
+      operationFeePolicy: .estimate
+    ) { result in
+      switch result {
+      case .success(let opHash):
+        self.opHash = opHash
+      case .failure(let error):
+        print("error :( \(error)")
+      }
+    }
   }
 
   @objc
   func openFn() {
-    let url = URL(string: "https://alphanet.tzscan.io/" + opHash!)!
+    let url = URL(string: "https://babylonnet.tzstats.com/" + opHash!)!
     UIApplication.shared.open(url)
   }
-
 }

--- a/Examples/SecureEnclave/ViewController.swift
+++ b/Examples/SecureEnclave/ViewController.swift
@@ -1,0 +1,127 @@
+//
+//  ViewController.swift
+//  Enclave
+//
+//  Created by Keefer Taylor on 5/1/19.
+//  Copyright © 2019 Keefer Taylor. All rights reserved.
+//
+import TezosKit
+import UIKit
+
+class BackgroundHighlightedButton: UIButton {
+  @IBInspectable var highlightedBackgroundColor: UIColor?
+  @IBInspectable var nonHighlightedBackgroundColor: UIColor?
+  override var isHighlighted: Bool {
+    get {
+      return super.isHighlighted
+    }
+    set {
+      if newValue {
+        self.backgroundColor = .blue
+      } else {
+        self.backgroundColor = .gray
+      }
+      super.isHighlighted = isHighlighted
+    }
+  }
+}
+
+class ViewController: UIViewController {
+  public let titleLabel: UILabel = UILabel()
+
+  public let generateKey: UIButton = BackgroundHighlightedButton()
+  public let pkh: UILabel = UILabel()
+  public let genKey: UILabel = UILabel()
+  public let dest: UILabel = UILabel()
+  public let destKey: UILabel = UILabel()
+
+  var nodeClient: TezosNodeClient?
+
+  public let signTransaction: UIButton = BackgroundHighlightedButton()
+  public let h = UILabel()
+  public let hash2 = UILabel()
+
+  public let open: UIButton = BackgroundHighlightedButton()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+//    title.setTitle("Tezos Secure Enclave Signing")
+    generateKey.setTitle("Generate Key", for: .normal)
+    generateKey.frame = CGRect(x: 50, y: 200, width: 300, height: 50)
+    generateKey.backgroundColor = .gray
+    generateKey.addTarget(self, action: #selector(generate), for: .touchUpInside)
+    self.view.addSubview(generateKey)
+
+    pkh.text = "Public Key Hash:"
+    pkh.frame = CGRect(x: 50, y: 270, width: 300, height: 20)
+    self.view.addSubview(pkh)
+
+    genKey.text = ""
+    genKey.frame = CGRect(x: 50, y: 310, width: 300, height: 20)
+    self.view.addSubview(genKey)
+
+    dest.text = "Destination:"
+    dest.frame = CGRect(x: 50, y: 350, width: 300, height: 20)
+    self.view.addSubview(dest)
+
+    destKey.text = "tz1NpWrAyDL9k2Lmnyxcgr9xuJakbBxdq7FB"
+    destKey.frame = CGRect(x: 50, y: 390, width: 300, height: 20)
+    self.view.addSubview(destKey)
+
+    signTransaction.setTitle("Sign And Broadcast", for: .normal)
+    signTransaction.frame = CGRect(x: 50, y: 460, width: 300, height: 50)
+    signTransaction.backgroundColor = .gray
+    signTransaction.addTarget(self, action: #selector(send), for: .touchUpInside)
+    self.view.addSubview(signTransaction)
+
+    h.text = "Operation Hash:"
+    h.frame = CGRect(x: 50, y: 530, width: 300, height: 20)
+    self.view.addSubview(h)
+
+    hash2.text = ""
+    hash2.frame = CGRect(x: 50, y: 570, width: 300, height: 20)
+    self.view.addSubview(hash2)
+
+    open.setTitle("Open in TzScan", for: .normal)
+    open.frame = CGRect(x: 50, y: 610, width: 300, height: 50)
+    open.backgroundColor = .gray
+    open.addTarget(self, action: #selector(openFn), for: .touchUpInside)
+    self.view.addSubview(open)
+  }
+
+  @objc
+  func generate() {
+    // TODO: Update this
+    // TODO: REcall key compression.
+    genKey.text = "tz3fq2juip9PQfxnQ5JTdwzEscdkVpWi2rTs"
+  }
+
+  var opHash: String?
+
+  @objc
+  func send() {
+//    let nodeURL = URL(string: "http://alphanet-node.tzscan.io:80")! // URL(string: "http://127.0.0.1:8732")!
+//    nodeClient = TezosNodeClient(remoteNodeURL: nodeURL)
+//
+//    let wallet = Wallet()!
+//    nodeClient!.send(
+//    amount: Tez("1")!, to: "tz1NpWrAyDL9k2Lmnyxcgr9xuJakbBxdq7FB", from: "tz3fq2juip9PQfxnQ5JTdwzEscdkVpWi2rTs", keys: wallet) { result in
+//      switch result {
+//      case .failure(let error):
+//        print("WRONG")
+//        print(error)
+//      case .success(let hash):
+//        self.opHash = hash
+//        self.hash2.text = hash
+//      }
+//    }
+  }
+
+  @objc
+  func openFn() {
+    let url = URL(string: "https://alphanet.tzscan.io/" + opHash!)!
+    UIApplication.shared.open(url)
+  }
+
+}

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		64185B7D0E39391674A70F5A /* OperationPayloadFactoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFE3E8D18069FFC9F79BF11D /* OperationPayloadFactoryTest.swift */; };
 		649E1CC62E843A2E2282421F /* NetworkClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CD7E1718D9928582CA4984 /* NetworkClientTest.swift */; };
 		64F80C86597E217AD2DEC700 /* ConseilClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0922D1ADC86CC9907C3EEBA2 /* ConseilClient+Promises.swift */; };
+		650FC94D0C144F4B84340A47 /* BackgroundHighlightedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ACC81B5F0A5B255B1BAC216 /* BackgroundHighlightedButton.swift */; };
 		657E1EEDBFB199F02B80A690 /* Prefixes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A77AE24F8BDC52A906F1A10 /* Prefixes.swift */; };
 		659CED6B752092E389F25617 /* Sodium+TezosCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8373F22F20972134DC7B3DC4 /* Sodium+TezosCrypto.swift */; };
 		661D5439AA293CB6889B44D0 /* PreapplicationServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FCF6EFDB51394D49E1479C /* PreapplicationServiceTest.swift */; };
@@ -620,6 +621,7 @@
 		274BAF5E1A4B223F09042484 /* DexterExchangeClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DexterExchangeClientTests.swift; sourceTree = "<group>"; };
 		274E2A45E6EB2DCA9A6D1E3F /* OperationWithCounterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationWithCounterTest.swift; sourceTree = "<group>"; };
 		29024177105AD82662279805 /* AbstractResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractResponseAdapter.swift; sourceTree = "<group>"; };
+		2ACC81B5F0A5B255B1BAC216 /* BackgroundHighlightedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundHighlightedButton.swift; sourceTree = "<group>"; };
 		2B1E035A6252AD79E6A4AAD1 /* SigningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningService.swift; sourceTree = "<group>"; };
 		2B3D7B0277CE3BF6560DFD91 /* MnemonicUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MnemonicUtilsTest.swift; sourceTree = "<group>"; };
 		2FFED1AB3870A0537888D39E /* GetChainHeadHashRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChainHeadHashRPCTest.swift; sourceTree = "<group>"; };
@@ -1109,6 +1111,7 @@
 		4702E78977B4BF7B59133F2A /* SecureEnclave */ = {
 			isa = PBXGroup;
 			children = (
+				2ACC81B5F0A5B255B1BAC216 /* BackgroundHighlightedButton.swift */,
 				E5810E505C141C6B652D0356 /* Enclave.entitlements */,
 				C014CF988B5D6585A97BC0DA /* Info.plist */,
 				103F9F9791635574BDC25318 /* LaunchScreen.storyboard */,
@@ -2118,6 +2121,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				650FC94D0C144F4B84340A47 /* BackgroundHighlightedButton.swift in Sources */,
 				6BAC12E4806ADAAA3FC90513 /* SecureEnclaveAppDelegate.swift in Sources */,
 				2A621635D7502E2635CAD72C /* ViewController.swift in Sources */,
 			);

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		2013A0800E3CF2A9902E0354 /* SecretKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E564AA5901EF3BB2FCF79397 /* SecretKeyTests.swift */; };
 		20C16CFCB554CF81CB2CF03C /* ForgingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2035C617A6D99FFB50ED1842 /* ForgingService.swift */; };
 		20E9FCE054F634DB3EBE0352 /* StringMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCF66588A24A65AA37CC90C /* StringMichelsonParameter.swift */; };
+		21D16434E5CA699713465031 /* TezosKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 632B9078CDB2B8EC754A858F /* TezosKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		21DFB6D5F1C38A65473294A4 /* GetBallotsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84952454AD66BD8E378047D /* GetBallotsRPC.swift */; };
 		231A8423F33E60910EC2C9E7 /* TransactionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D8230197EBFE429B4C99611 /* TransactionTest.swift */; };
 		232A22C322ECB499CE1ABB97 /* PreapplyOperationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = B033280AD0AE71CF00F15555 /* PreapplyOperationRPC.swift */; };
@@ -72,6 +73,7 @@
 		27641CCD3D8C9AC9A6719869 /* PeriodKindResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B64C2C9B1E8CA1987CC98B /* PeriodKindResponseAdapter.swift */; };
 		295CD232F78E4BF22DF07836 /* GetExpectedQuorumRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68B50E6C20187E9AC1CDB8E /* GetExpectedQuorumRPCTest.swift */; };
 		29E4A4AC683B33EFF8D6E0AE /* SimulationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6736E66F6C33A71E96D8AA57 /* SimulationResult.swift */; };
+		2A621635D7502E2635CAD72C /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18027B5B88EBBF5C5FD9B1F8 /* ViewController.swift */; };
 		2B6489B6FC91E02E2474922C /* UnitMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D650111C52C89A65467CC889 /* UnitMichelsonParameter.swift */; };
 		2BC5814E801A9DE73F1005E3 /* GetProposalUnderEvaluationRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A43F54FBE7049C2AAE4183 /* GetProposalUnderEvaluationRPCTest.swift */; };
 		2D0CE54716647A1E451F4656 /* BigInt.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95F395F6CD3F62BF5D3FCED1 /* BigInt.framework */; };
@@ -90,6 +92,7 @@
 		34E43B75D92CE9FE2726F960 /* ConseilClientIntegrationTests+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B2484FD06C8D95BB5ACDCC /* ConseilClientIntegrationTests+Promises.swift */; };
 		35079BDCFCAA9CC2FF318C53 /* GetBigMapValueByIDRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC366A9719F3F6D07093E37 /* GetBigMapValueByIDRPC.swift */; };
 		3591C65A03D45513CC06B457 /* AbstractOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5FAF254AF66B1A805ABF27 /* AbstractOperationTest.swift */; };
+		35CBE4BFF9664D1757E88E8A /* TezosKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 632B9078CDB2B8EC754A858F /* TezosKit.framework */; };
 		3698330EA50903CD0AEEC185 /* Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6067C4058BC42C52B64AF93A /* Hex.swift */; };
 		369AFABBC4DC7B34F4122FE7 /* GetAddressCounterRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF147FA8F9FDDEBA70FA2759 /* GetAddressCounterRPC.swift */; };
 		381DBFEA8AB85D0A93AD40FE /* TestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1D1F6B1DDF04EB174551D3 /* TestObjects.swift */; };
@@ -129,6 +132,7 @@
 		4F2F78B301A1CE1C55EE77BA /* TezosNodeClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6AA3CAB521F463866CFB96 /* TezosNodeClient+Promises.swift */; };
 		4F48F1939F7FBC9EF5D8EBFA /* secp256k1.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D8FD368E4F600E8C2A2D1D3A /* secp256k1.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4FCF97E349053D21AE8E506E /* GetProposalUnderEvaluationRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 407B756EB7320CC968E1C2ED /* GetProposalUnderEvaluationRPC.swift */; };
+		4FF49B2B994C90E6844FC1A6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 103F9F9791635574BDC25318 /* LaunchScreen.storyboard */; };
 		507040285C936250D661F395 /* BigInt.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95F395F6CD3F62BF5D3FCED1 /* BigInt.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		50D2C68AA4145527E3333F6F /* StringResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7B474664A9C0C8EA93EA08 /* StringResponseAdapterTest.swift */; };
 		50D5AF8F52F0363F90F9EF6D /* GetDelegateRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA474C90E513C4377433A85C /* GetDelegateRPCTest.swift */; };
@@ -152,6 +156,7 @@
 		59A2F834737A398C874C200B /* TezosNodeClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A480E400F3C3D065639376F4 /* TezosNodeClientTests.swift */; };
 		59F27929724F9EF92946A3FC /* GetOriginatedContractsRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7008A9105E3151B6B23496F1 /* GetOriginatedContractsRPC.swift */; };
 		5AAA401A5BDA0FDE53C38EBC /* WalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1596A9E29DF24E63C454D2DD /* WalletTests.swift */; };
+		5B890ECF354B9F86749465BC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F09693A9394BBB8038CDC63A /* Main.storyboard */; };
 		5B9C772D561E314CE6957CBD /* GetChainHeadRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4252DFDE63B35970A3B59A /* GetChainHeadRPCTest.swift */; };
 		5C243C48B85DBB99E58CE34C /* AbstractResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29024177105AD82662279805 /* AbstractResponseAdapter.swift */; };
 		5C9E6119D5B8F50A8C076024 /* GasLimitPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F867E1CE5F1920E101259B /* GasLimitPolicy.swift */; };
@@ -183,6 +188,7 @@
 		6A010379E6D6E1574A25E439 /* SigningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1E035A6252AD79E6A4AAD1 /* SigningService.swift */; };
 		6AC4FC819BE657D545D58D65 /* TokenContractClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE8CAB1EBF88156948D30F4 /* TokenContractClient.swift */; };
 		6ADF54D797E8287A5DD92EC5 /* OperationMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A057E76CA636DDEE045ED59C /* OperationMetadataProvider.swift */; };
+		6BAC12E4806ADAAA3FC90513 /* SecureEnclaveAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CBDE12B45607651E7042226 /* SecureEnclaveAppDelegate.swift */; };
 		6C211B5899F3AB595386C678 /* JSONDictionaryResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653FD23DE712676D0DFCA7D2 /* JSONDictionaryResponseAdapter.swift */; };
 		6D8731CE158D6378887B5A33 /* ConseilClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0922D1ADC86CC9907C3EEBA2 /* ConseilClient+Promises.swift */; };
 		6D91DBD85F5F525826CC55FE /* GetContractStorageRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C07BA2584C54711181C33DE /* GetContractStorageRPC.swift */; };
@@ -480,6 +486,13 @@
 			remoteGlobalIDString = 060BEF471E9C532F4D695365;
 			remoteInfo = TezosKit_iOS;
 		};
+		E2AB7FF80BFA9ED0DA7678A4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ACD213B01AB647B1C912BFF7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 060BEF471E9C532F4D695365;
+			remoteInfo = TezosKit_iOS;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -559,6 +572,17 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A813644CC01901D5F77F8445 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				21D16434E5CA699713465031 /* TezosKit.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -584,6 +608,7 @@
 		1564F45DEFBC0D755FAB0218 /* GetSentTransactionsRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSentTransactionsRPC.swift; sourceTree = "<group>"; };
 		1596A9E29DF24E63C454D2DD /* WalletTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTests.swift; sourceTree = "<group>"; };
 		170AD904F169111FBCD93FCC /* DelegationOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegationOperation.swift; sourceTree = "<group>"; };
+		18027B5B88EBBF5C5FD9B1F8 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		18257A644A0B08F1E48E8808 /* LeftMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftMichelsonParameter.swift; sourceTree = "<group>"; };
 		1BCD5416B3E149D9389F6961 /* ConseilClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilClientTests.swift; sourceTree = "<group>"; };
 		1DC8C35C8541E0CBE377968D /* IntMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntMichelsonParameter.swift; sourceTree = "<group>"; };
@@ -625,6 +650,7 @@
 		4E006B0AA63CD2D50D07762F /* GetExpectedQuorumRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetExpectedQuorumRPC.swift; sourceTree = "<group>"; };
 		510562653A6F7930885D3F55 /* PackDataPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackDataPayload.swift; sourceTree = "<group>"; };
 		525C931C7CD120487B51DA9A /* MichelsonComparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MichelsonComparable.swift; sourceTree = "<group>"; };
+		52D1D096C31DAEC20CFDBD89 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		53BA885B9E3E1F6BA3693A3F /* SignedProtocolOperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedProtocolOperationPayload.swift; sourceTree = "<group>"; };
 		55B2484FD06C8D95BB5ACDCC /* ConseilClientIntegrationTests+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConseilClientIntegrationTests+Promises.swift"; sourceTree = "<group>"; };
 		588112F5BDBF5213EB952EF1 /* NoneMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoneMichelsonParameter.swift; sourceTree = "<group>"; };
@@ -662,6 +688,7 @@
 		7AD76EFEED13EEB01FF11D1D /* secp256k1.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = secp256k1.framework; sourceTree = "<group>"; };
 		7B2A43B6B3647D2CE712D1B0 /* OperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationPayload.swift; sourceTree = "<group>"; };
 		7C07BA2584C54711181C33DE /* GetContractStorageRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContractStorageRPC.swift; sourceTree = "<group>"; };
+		7CBDE12B45607651E7042226 /* SecureEnclaveAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureEnclaveAppDelegate.swift; sourceTree = "<group>"; };
 		7D8230197EBFE429B4C99611 /* TransactionTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionTest.swift; sourceTree = "<group>"; };
 		7DF606714D021D4EFFA07E6A /* GetBallotsListRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBallotsListRPC.swift; sourceTree = "<group>"; };
 		81BC48461432501639D06FD6 /* AbstractOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractOperation.swift; sourceTree = "<group>"; };
@@ -728,6 +755,7 @@
 		BCF068374D26E5AD6CE93407 /* TezResponseAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezResponseAdapter.swift; sourceTree = "<group>"; };
 		BF24BCDA4254C7A2D50F5728 /* ConseilQueryRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilQueryRPC.swift; sourceTree = "<group>"; };
 		BFC366A9719F3F6D07093E37 /* GetBigMapValueByIDRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBigMapValueByIDRPC.swift; sourceTree = "<group>"; };
+		C014CF988B5D6585A97BC0DA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C1968AE0A3A2B4DAD756FD72 /* ConseilClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilClientIntegrationTests.swift; sourceTree = "<group>"; };
 		C1FCF6EFDB51394D49E1479C /* PreapplicationServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreapplicationServiceTest.swift; sourceTree = "<group>"; };
 		C525A21D32496E9B7BB4F79A /* GetAddressCounterRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressCounterRPCTest.swift; sourceTree = "<group>"; };
@@ -748,11 +776,13 @@
 		D8DD132F238141B3A1D24CC3 /* PublicKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKey.swift; sourceTree = "<group>"; };
 		D8FD368E4F600E8C2A2D1D3A /* secp256k1.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = secp256k1.framework; sourceTree = "<group>"; };
 		D9F5DCCA68E890BE7185F769 /* DexterExchangeClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DexterExchangeClientIntegrationTests.swift; sourceTree = "<group>"; };
+		DEAEB55943792CC3F5CE052C /* SecureEnclaveExample.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SecureEnclaveExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0B48169F083D2DAEB462840 /* SimulationServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimulationServiceTest.swift; sourceTree = "<group>"; };
 		E212CD2F0656857B66156D04 /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
 		E4B3BE4BAECB893457A44FC1 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		E564AA5901EF3BB2FCF79397 /* SecretKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretKeyTests.swift; sourceTree = "<group>"; };
 		E57EC805C27A406AF0C4B17E /* Base58+TezosCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Base58+TezosCrypto.swift"; sourceTree = "<group>"; };
+		E5810E505C141C6B652D0356 /* Enclave.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Enclave.entitlements; sourceTree = "<group>"; };
 		E7A2247E719CDA0FA064FBD3 /* ForgingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgingServiceTests.swift; sourceTree = "<group>"; };
 		E7E04ED6C09C75468839B5F3 /* RevealOperationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevealOperationTest.swift; sourceTree = "<group>"; };
 		EA4EFB572B203694CE5AD6B7 /* PublicKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKeyTests.swift; sourceTree = "<group>"; };
@@ -770,6 +800,7 @@
 		F74BC96BBBBF950226E07E85 /* PreapplicationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreapplicationService.swift; sourceTree = "<group>"; };
 		F7B9AE14DF5799CA2EEFDCD9 /* PairMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairMichelsonParameter.swift; sourceTree = "<group>"; };
 		FA474C90E513C4377433A85C /* GetDelegateRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDelegateRPCTest.swift; sourceTree = "<group>"; };
+		FAB03FFC00D4A6630FEE9DB5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		FBE0279DC6099EED8F2D4CF9 /* OperationPayloadFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationPayloadFactory.swift; sourceTree = "<group>"; };
 		FC385B9CD31989369391F0B6 /* PreapplyOperationRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreapplyOperationRPCTest.swift; sourceTree = "<group>"; };
 		FC4252DFDE63B35970A3B59A /* GetChainHeadRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChainHeadRPCTest.swift; sourceTree = "<group>"; };
@@ -839,6 +870,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5971B2AD3A770CAC779C482 /* TezosKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A53495D66EF06CDD45DE1CB9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				35CBE4BFF9664D1757E88E8A /* TezosKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -998,6 +1037,7 @@
 		39C9B251ED1E92F476D590CD /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				DEAEB55943792CC3F5CE052C /* SecureEnclaveExample.app */,
 				632B9078CDB2B8EC754A858F /* TezosKit.framework */,
 				D4CC2EFE37BC672A082A9F69 /* TezosKit.framework */,
 				6EF6AE2D1FDA4575445E424F /* TezosKitIntegrationTests.xctest */,
@@ -1035,6 +1075,7 @@
 				D231A0952D7582EAE9B5877D /* Common */,
 				50C91A025E54A221B684A314 /* Extensions */,
 				69291FDD3EDCCD2E9D0374A2 /* IntegrationTests */,
+				4702E78977B4BF7B59133F2A /* SecureEnclave */,
 				33E21EC5719A93EF7D496C85 /* TezosKit */,
 				E67B87D587558F51971F43BF /* UnitTests */,
 				FE4EEFBC6C12C0D326D4CFF0 /* Frameworks */,
@@ -1063,6 +1104,20 @@
 				E212CD2F0656857B66156D04 /* NetworkClient.swift */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		4702E78977B4BF7B59133F2A /* SecureEnclave */ = {
+			isa = PBXGroup;
+			children = (
+				E5810E505C141C6B652D0356 /* Enclave.entitlements */,
+				C014CF988B5D6585A97BC0DA /* Info.plist */,
+				103F9F9791635574BDC25318 /* LaunchScreen.storyboard */,
+				F09693A9394BBB8038CDC63A /* Main.storyboard */,
+				7CBDE12B45607651E7042226 /* SecureEnclaveAppDelegate.swift */,
+				18027B5B88EBBF5C5FD9B1F8 /* ViewController.swift */,
+			);
+			name = SecureEnclave;
+			path = Examples/SecureEnclave;
 			sourceTree = "<group>";
 		};
 		4FB8A8575ACE00EFC4FCD4BC /* Conseil */ = {
@@ -1427,6 +1482,26 @@
 			productReference = D4CC2EFE37BC672A082A9F69 /* TezosKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		40E6F7EA85DABF926B767956 /* SecureEnclaveExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5AE7D52DF5AEC79050B10C6C /* Build configuration list for PBXNativeTarget "SecureEnclaveExample" */;
+			buildPhases = (
+				E6503F8F27D24E7EE00E840F /* Sources */,
+				304678ECDFD451FFD87D287E /* Resources */,
+				D57827DD459651A390BC3CE7 /* Carthage */,
+				A53495D66EF06CDD45DE1CB9 /* Frameworks */,
+				A813644CC01901D5F77F8445 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8BBF080F1B617050C08EF682 /* PBXTargetDependency */,
+			);
+			name = SecureEnclaveExample;
+			productName = SecureEnclaveExample;
+			productReference = DEAEB55943792CC3F5CE052C /* SecureEnclaveExample.app */;
+			productType = "com.apple.product-type.application";
+		};
 		52946DAA15AD57EF4099981F /* TezosKitTests_macOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D5329372F59B0FE5C0A4DE2F /* Build configuration list for PBXNativeTarget "TezosKitTests_macOS" */;
@@ -1513,12 +1588,12 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				Base,
-				en,
 			);
 			mainGroup = 40497E8417609B6A929D29D7;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				40E6F7EA85DABF926B767956 /* SecureEnclaveExample */,
 				9281FA65EDC27A6CAB1611C0 /* TezosKitIntegrationTests_iOS */,
 				7EDB40654EDDE5BFA914A2AB /* TezosKitIntegrationTests_macOS */,
 				7271E9FDF8CE0133691B2049 /* TezosKitTests_iOS */,
@@ -1528,6 +1603,18 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		304678ECDFD451FFD87D287E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4FF49B2B994C90E6844FC1A6 /* LaunchScreen.storyboard in Resources */,
+				5B890ECF354B9F86749465BC /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		AE8B915A5B4F831998C988FD /* SwiftLint */ = {
@@ -1565,6 +1652,36 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "swiftlint autocorrect --config .swiftlint.yml";
+		};
+		D57827DD459651A390BC3CE7 /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/Base58Swift.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/BigInt.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/CryptoSwift.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/MnemonicKit.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/PromiseKit.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/SipHash.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/Sodium.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/secp256k1.framework",
+			);
+			name = Carthage;
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Base58Swift.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/BigInt.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/CryptoSwift.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/MnemonicKit.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/PromiseKit.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/SipHash.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Sodium.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/secp256k1.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1997,6 +2114,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E6503F8F27D24E7EE00E840F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6BAC12E4806ADAAA3FC90513 /* SecureEnclaveAppDelegate.swift in Sources */,
+				2A621635D7502E2635CAD72C /* ViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -2004,6 +2130,11 @@
 			isa = PBXTargetDependency;
 			target = 40B6FF29BF546CEDBE05C1E8 /* TezosKit_macOS */;
 			targetProxy = C8E39CD7BD1AE63317CC7D1A /* PBXContainerItemProxy */;
+		};
+		8BBF080F1B617050C08EF682 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 060BEF471E9C532F4D695365 /* TezosKit_iOS */;
+			targetProxy = E2AB7FF80BFA9ED0DA7678A4 /* PBXContainerItemProxy */;
 		};
 		A9D26E1E6B6D5B4DD22112B6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2021,6 +2152,25 @@
 			targetProxy = 0E118F694870FE4BC82C4EE6 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		103F9F9791635574BDC25318 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				52D1D096C31DAEC20CFDBD89 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		F09693A9394BBB8038CDC63A /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				FAB03FFC00D4A6630FEE9DB5 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		0197C92CBF2A268F5E69B46F /* Debug */ = {
@@ -2104,6 +2254,27 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.keefertaylor.TezosKitIntegrationTests-macOS";
 				PRODUCT_NAME = TezosKitIntegrationTests;
 				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		25B8AD7D3BFE27A3D79DC395 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Examples/SecureEnclave/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.SecureEnclaveExample;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -2415,6 +2586,27 @@
 			};
 			name = Release;
 		};
+		F9D58DC09E265661F5E89566 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Examples/SecureEnclave/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.keefertaylor.SecureEnclaveExample;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2432,6 +2624,15 @@
 			buildConfigurations = (
 				0197C92CBF2A268F5E69B46F /* Debug */,
 				2241CF12ED027ABD0A8DF44F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		5AE7D52DF5AEC79050B10C6C /* Build configuration list for PBXNativeTarget "SecureEnclaveExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F9D58DC09E265661F5E89566 /* Debug */,
+				25B8AD7D3BFE27A3D79DC395 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";

--- a/project.yml
+++ b/project.yml
@@ -38,3 +38,10 @@ targets:
     sources: [Tests/IntegrationTests, Tests/Common]
     dependencies:
       - target: TezosKit_${platform}
+  SecureEnclaveExample:
+    type: application
+    platform: iOS
+    deploymentTarget: "10.0"
+    sources: [Examples/SecureEnclave]
+    dependencies:
+      - target: TezosKit_iOS


### PR DESCRIPTION
Quick demo app that lets users generate a wallet and send transactions.  This is needed because the iOS Simulator doesn't have iOS secure enclave functionality built in. 

Note that despite the name, this is still just using in memory wallet generation (via the standard ed25519 curve). In the future, this app will migrate to using an enclave. 