### PR TITLE
make operation factory on tezosNodeClient public, read only

### DIFF
--- a/TezosKit/TezosNode/TezosNodeClient.swift
+++ b/TezosKit/TezosNode/TezosNodeClient.swift
@@ -72,7 +72,7 @@ public class TezosNodeClient {
   public static let defaultNodeURL = URL(string: "https://rpc.tezrpc.me")!
 
   /// A factory which produces operations.
-  internal let operationFactory: OperationFactory
+  public let operationFactory: OperationFactory
 
   /// A service which forges operations.
   internal let forgingService: ForgingService


### PR DESCRIPTION
Up for discussion, but I found I needed access to the operation factory on the tezosNodeClient.

**Scenario:**
- present a screen for user to send Tez to someone
- present a confirmation screen before sending, showing the fees and remaining balance before sending

**Problem:**
OperationFactory, FeeEstimator and the functions used are all private / internal. Getting the fees requires creating an OperationFactory, which requires a FeeEstimator, which needs a SimulatonService, which needs a NetworkClient and so on. The result being having to duplicate all the internal vars just to use the same logic, and requires knowing a lot about the SDK and Tezos.

Making OperationFactory public means you can create

```
let transactionOperation = tezosNodeClient.operationFactory.transactionOperation( ... )
```

Display `transactionOperation?.operationFees.fee` to the user and if they click send, pass the transaction  back into the tezosNodeClient.