### PR TITLE
Basic RPC logging

### DIFF
--- a/TezosKit/Common/Services/NetworkClient.swift
+++ b/TezosKit/Common/Services/NetworkClient.swift
@@ -1,6 +1,7 @@
 // Copyright Keefer Taylor, 2019
 
 import Foundation
+import os.log
 
 /// An opaque network client which implements requests.
 public protocol NetworkClient {
@@ -108,11 +109,21 @@ public class NetworkClientImpl: NetworkClient {
     for header in rpc.headers {
       urlRequest.addValue(header.value, forHTTPHeaderField: header.field)
     }
-
+	
     let request = urlSession.dataTask(with: urlRequest) { [weak self] data, response, error in
       guard let self = self else {
         return
       }
+	  
+	  if rpc is RunOperationRPC || rpc is PreapplyOperationRPC,
+		let data = data, let dataString = String(data: data, encoding: .utf8)
+	  {
+		  if #available(iOS 12.0, *) {
+			  os_log(.debug, log: OSLog(subsystem: Bundle.main.bundleIdentifier ?? "TezosKit", category: "TezosKit"), "RPC Response: %@", dataString)
+		  } else {
+			  print("[TezosKit] RPC Response: \(dataString)")
+		  }
+	  }
 
       let result = self.responseHandler.handleResponse(
         response: response,


### PR DESCRIPTION
A very simple / basic attempt to address: https://github.com/keefertaylor/TezosKit/issues/181 

For debugging purposes, especially creating and experimenting with smart contracts, developers will need to be able to see the RPC responses. Using os_log also means QA teams will be able to make use of the Mac console app to help developers if there is an issue.

Ideally this should be configurable, but I don't have the bandwidth at this time to improve on it. Feel to extend or repurpose it into something better.


on a side note, indentation set to 2 spaces and not using tabs? ... who hurt you? ha