### PR TITLE
Fix bug where `signingCurve` wasn't respected

### DIFF
--- a/Tests/UnitTests/TezosKit/SecretKeyTests.swift
+++ b/Tests/UnitTests/TezosKit/SecretKeyTests.swift
@@ -78,30 +78,28 @@ final class SecretKeyTests: XCTestCase {
   // MARK: - secp256k1
 
   func testBase58CheckRepresentation_secp256k1() {
-    let secretKeyBase58 = "spsk1zkqrmst1yg2c4xi3crWcZPqgdc9KtPtb9SAZWYHAdiQzdHy7j"
-    guard
-      let secretKeyBytes = Base58.base58CheckDecodeWithPrefix(
-        string: secretKeyBase58,
-        prefix: Prefix.Keys.Secp256k1.secret
-      )
-    else {
-      XCTFail("Unable to decode secret key bytes")
+    guard let secretKey = SecretKey(mnemonic: .mnemonic, signingCurve: .secp256k1) else {
+      XCTFail()
       return
     }
 
-    let secretKey = SecretKey(secretKeyBytes, signingCurve: .secp256k1)
     XCTAssertEqual(
       secretKey.base58CheckRepresentation,
-      secretKeyBase58
+      "spsk2yoh33fRH4nt95Xf3BySX5pR5Zok2adQxsb9P9koj3A4xAsAfk"
     )
   }
 
   func testInitFromBase58CheckRepresntation_ValidString_secp256k1() {
-    let base58Representation = "spsk2rBDDeUqakQ42nBHDGQTtP3GErb6AahHPwF9bhca3Q5KA5HESE"
-    let secretKeyFromString =
-      SecretKey(base58Representation, signingCurve: .secp256k1)
-    XCTAssertNotNil(secretKeyFromString)
-    XCTAssertEqual(secretKeyFromString?.base58CheckRepresentation, base58Representation)
+    let base58Representation = "spsk1fYtbGsvDEeb4NGanSiYQYcLFNZYNZ9F7jSvmCbT55DHcbtWjL"
+    guard let secretKey = SecretKey(base58Representation, signingCurve: .secp256k1) else {
+      XCTFail("Could not derive a secret key")
+      return
+    }
+    XCTAssertNotNil(secretKey)
+    XCTAssertEqual(secretKey.base58CheckRepresentation, base58Representation)
+
+    let publicKey = PublicKey(secretKey: secretKey)
+    XCTAssertEqual(publicKey?.publicKeyHash, "tz2D3CdkJsR3X5zvvdvsbeGN2NMWoByLs1kM")
   }
 
   func testInitFromBase58CheckRepresentation_InvalidBase58_secp256k1() {

--- a/Tests/UnitTests/TezosKit/SecretKeyTests.swift
+++ b/Tests/UnitTests/TezosKit/SecretKeyTests.swift
@@ -78,14 +78,21 @@ final class SecretKeyTests: XCTestCase {
   // MARK: - secp256k1
 
   func testBase58CheckRepresentation_secp256k1() {
-    guard let secretKey = SecretKey(mnemonic: .mnemonic, signingCurve: .secp256k1) else {
-      XCTFail()
+    let secretKeyBase58 = "spsk1zkqrmst1yg2c4xi3crWcZPqgdc9KtPtb9SAZWYHAdiQzdHy7j"
+    guard
+      let secretKeyBytes = Base58.base58CheckDecodeWithPrefix(
+        string: secretKeyBase58,
+        prefix: Prefix.Keys.Secp256k1.secret
+      )
+    else {
+      XCTFail("Unable to decode secret key bytes")
       return
     }
 
+    let secretKey = SecretKey(secretKeyBytes, signingCurve: .secp256k1)
     XCTAssertEqual(
       secretKey.base58CheckRepresentation,
-      "edskS4pbuA7rwMjsZGmHU18aMP96VmjegxBzwMZs3DrcXHcMV7VyfQLkD5pqEE84wAMHzi8oVZF6wbgxv3FKzg7cLqzURjaXUp"
+      secretKeyBase58
     )
   }
 

--- a/Tests/UnitTests/TezosKit/WalletTests.swift
+++ b/Tests/UnitTests/TezosKit/WalletTests.swift
@@ -156,4 +156,35 @@ class WalletTests: XCTestCase {
       ]
     )
   }
+
+  func testWalletGenerationCurvesWithMnemonic() {
+    let passphrase = "tezoskit"
+    guard
+      let tz1Wallet = Wallet(passphrase: passphrase, signingCurve: .ed25519),
+      let tz2Wallet = Wallet(passphrase: passphrase, signingCurve: .secp256k1)
+    else {
+      XCTFail("Failed to generate wallets.")
+      return
+    }
+
+    XCTAssertEqual(tz1Wallet.publicKey.signingCurve, .ed25519)
+    XCTAssertEqual(tz2Wallet.publicKey.signingCurve, .secp256k1)
+  }
+
+  func testWalletGenerationCurvesWithSeed() {
+    let tz1SecretKey =
+      "edskRw8ZJM3P3f81VnfChULCLh7KwhZMvp6rniDHNeEcQiNBevrTkwtzYwtqmEvbf5HJTQeb1WvTL5UUcsMjVh5RZArcRdXbQC"
+    let tz2SecretKey =
+      "spsk1fYtbGsvDEeb4NGanSiYQYcLFNZYNZ9F7jSvmCbT55DHcbtWjL"
+    guard
+      let tz1Wallet = Wallet(secretKey: tz1SecretKey, signingCurve: .ed25519),
+      let tz2Wallet = Wallet(secretKey: tz2SecretKey, signingCurve: .secp256k1)
+    else {
+      XCTFail("Failed to generate wallets.")
+      return
+    }
+
+    XCTAssertEqual(tz1Wallet.publicKey.signingCurve, .ed25519)
+    XCTAssertEqual(tz2Wallet.publicKey.signingCurve, .secp256k1)
+  }
 }

--- a/TezosKit.xcodeproj/project.pbxproj
+++ b/TezosKit.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		649E1CC62E843A2E2282421F /* NetworkClientTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35CD7E1718D9928582CA4984 /* NetworkClientTest.swift */; };
 		64F80C86597E217AD2DEC700 /* ConseilClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0922D1ADC86CC9907C3EEBA2 /* ConseilClient+Promises.swift */; };
 		650FC94D0C144F4B84340A47 /* BackgroundHighlightedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ACC81B5F0A5B255B1BAC216 /* BackgroundHighlightedButton.swift */; };
+		6544833504DCEFD025688E90 /* RawMichelineMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6243223DA0B294EC6B575DF /* RawMichelineMichelsonParameter.swift */; };
 		657E1EEDBFB199F02B80A690 /* Prefixes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A77AE24F8BDC52A906F1A10 /* Prefixes.swift */; };
 		659CED6B752092E389F25617 /* Sodium+TezosCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8373F22F20972134DC7B3DC4 /* Sodium+TezosCrypto.swift */; };
 		661D5439AA293CB6889B44D0 /* PreapplicationServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1FCF6EFDB51394D49E1479C /* PreapplicationServiceTest.swift */; };
@@ -288,6 +289,7 @@
 		9772DD096F27A43644A5BE4B /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53D59AD9EA44F6B351A350F /* Transaction.swift */; };
 		9832CCBED4906F7744DAF714 /* TokenContractClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C4FA8521CE15740DE99596 /* TokenContractClientTests.swift */; };
 		985465FF0BF54FE8C17783B3 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 64FB9E39443B329830408289 /* README.md */; };
+		991D2C7E2C85AF62C0FFF390 /* OriginationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CCD5574FD830A21601E40E /* OriginationOperation.swift */; };
 		996D15B5EFC3C7EB7771BCC7 /* Base58+TezosCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57EC805C27A406AF0C4B17E /* Base58+TezosCrypto.swift */; };
 		99A8DDEC1498C877C4C5F662 /* DelegationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170AD904F169111FBCD93FCC /* DelegationOperation.swift */; };
 		99BF2A59BBAE320C233218AE /* GetExpectedQuorumRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E006B0AA63CD2D50D07762F /* GetExpectedQuorumRPC.swift */; };
@@ -362,10 +364,6 @@
 		BF58AA3718890216B35F94D1 /* SigningServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21DD030C2ACB7856608B34BA /* SigningServiceTests.swift */; };
 		BF8368AEC93713FD0257CB2A /* AbstractOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81BC48461432501639D06FD6 /* AbstractOperation.swift */; };
 		C0382A1E21312C3D3323732F /* BigInt.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7806BE5035AB3100BA7C791C /* BigInt.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		C073032F240FEEB8008A9B5B /* RawMichelineMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C073032E240FEEB8008A9B5B /* RawMichelineMichelsonParameter.swift */; };
-		C0730330240FEEB8008A9B5B /* RawMichelineMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C073032E240FEEB8008A9B5B /* RawMichelineMichelsonParameter.swift */; };
-		C0F9AE5F24098AC5002479FF /* OriginationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F9AE5E24098AC4002479FF /* OriginationOperation.swift */; };
-		C0F9AE6024098AC5002479FF /* OriginationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F9AE5E24098AC4002479FF /* OriginationOperation.swift */; };
 		C0FE1015DACEF52DD7FE3A33 /* TezosKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 632B9078CDB2B8EC754A858F /* TezosKit.framework */; };
 		C15CDCE9A538AB91764BCE7E /* LeftMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18257A644A0B08F1E48E8808 /* LeftMichelsonParameter.swift */; };
 		C3449CF9473642AADC85DC42 /* MichelsonAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 362C94B98BAA147AB9D080DC /* MichelsonAnnotationTests.swift */; };
@@ -444,6 +442,7 @@
 		EBB75619AA9E3C31007B00C1 /* DefaultFeeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66D157EC9056A7A23FBC45D /* DefaultFeeProvider.swift */; };
 		ED72915CAD746F7E86E36473 /* Prefixes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A77AE24F8BDC52A906F1A10 /* Prefixes.swift */; };
 		EDA29AC8F0817C3413B88661 /* GetAddressCounterRPCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C525A21D32496E9B7BB4F79A /* GetAddressCounterRPCTest.swift */; };
+		EE0CEC01367B4514A75342BE /* RawMichelineMichelsonParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6243223DA0B294EC6B575DF /* RawMichelineMichelsonParameter.swift */; };
 		EF0F55C1C1ABD3474DADDF52 /* SimulationResultResponseAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A251461CA96978E44F48E8D /* SimulationResultResponseAdapter.swift */; };
 		EF2B3C1238727F62AEC85C67 /* ManagerContractClientIntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA72575D3B6195B92BAA16F /* ManagerContractClientIntegrationTest.swift */; };
 		F009C015BB8F2701C05948E0 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFC77643CD2C374042E0B932 /* CryptoSwift.framework */; };
@@ -468,6 +467,7 @@
 		FA69D591490F2E93C465A258 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC64BA50EF400CF4B90951AA /* CryptoSwift.framework */; };
 		FAFE54CF7E5E0BC0D60B460E /* PromiseKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 33A83E353521083164433924 /* PromiseKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FBC6C42F1CA1E2C3347610A9 /* PackDataRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4567ADF69709F66F2EB345 /* PackDataRPC.swift */; };
+		FC0DA3A41819419D14A44BC8 /* OriginationOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60CCD5574FD830A21601E40E /* OriginationOperation.swift */; };
 		FC62BE3B01BE1641A8EA8FAC /* MnemonicUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3D7B0277CE3BF6560DFD91 /* MnemonicUtilsTest.swift */; };
 		FCFF1137D39FC8613661D401 /* SimulationResultResponseAdapterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7C3270399D4C501F334311 /* SimulationResultResponseAdapterTest.swift */; };
 		FD5F5426B85B61EEBDC02F32 /* secp256k1.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7AD76EFEED13EEB01FF11D1D /* secp256k1.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -686,6 +686,7 @@
 		5E2DD3668D2DD62AF8EDD738 /* TransactionsResponseAdapterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsResponseAdapterTest.swift; sourceTree = "<group>"; };
 		606292A7C4D50AD99EDC7208 /* ManagerContractClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagerContractClient.swift; sourceTree = "<group>"; };
 		6067C4058BC42C52B64AF93A /* Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hex.swift; sourceTree = "<group>"; };
+		60CCD5574FD830A21601E40E /* OriginationOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OriginationOperation.swift; sourceTree = "<group>"; };
 		61EDBE7577517E6ACF2498A2 /* MnemonicKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = MnemonicKit.framework; sourceTree = "<group>"; };
 		632B9078CDB2B8EC754A858F /* TezosKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TezosKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		63AB3DCEF101AC8B5CB3BEBD /* ConseilNetworkTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilNetworkTest.swift; sourceTree = "<group>"; };
@@ -760,6 +761,7 @@
 		A480E400F3C3D065639376F4 /* TezosNodeClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TezosNodeClientTests.swift; sourceTree = "<group>"; };
 		A4B1E1C9C5236B52B797EFA7 /* Address.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 		A4BE9708692F1E9BEFA4B1DA /* OperationMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationMetadata.swift; sourceTree = "<group>"; };
+		A6243223DA0B294EC6B575DF /* RawMichelineMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawMichelineMichelsonParameter.swift; sourceTree = "<group>"; };
 		A700A211C7AB1E92C5D7C3F4 /* SignedOperationPayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedOperationPayload.swift; sourceTree = "<group>"; };
 		A7284743A69C9A12186E4D67 /* Base58Swift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Base58Swift.framework; sourceTree = "<group>"; };
 		A84ECF4C95D1743641BEF321 /* TransactionOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionOperation.swift; sourceTree = "<group>"; };
@@ -787,8 +789,6 @@
 		BF24BCDA4254C7A2D50F5728 /* ConseilQueryRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilQueryRPC.swift; sourceTree = "<group>"; };
 		BFC366A9719F3F6D07093E37 /* GetBigMapValueByIDRPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBigMapValueByIDRPC.swift; sourceTree = "<group>"; };
 		C014CF988B5D6585A97BC0DA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		C073032E240FEEB8008A9B5B /* RawMichelineMichelsonParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawMichelineMichelsonParameter.swift; sourceTree = "<group>"; };
-		C0F9AE5E24098AC4002479FF /* OriginationOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OriginationOperation.swift; sourceTree = "<group>"; };
 		C1968AE0A3A2B4DAD756FD72 /* ConseilClientIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConseilClientIntegrationTests.swift; sourceTree = "<group>"; };
 		C1FCF6EFDB51394D49E1479C /* PreapplicationServiceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreapplicationServiceTest.swift; sourceTree = "<group>"; };
 		C525A21D32496E9B7BB4F79A /* GetAddressCounterRPCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAddressCounterRPCTest.swift; sourceTree = "<group>"; };
@@ -939,10 +939,10 @@
 				CE5EBE1E77B4458B18D149C1 /* Operation.swift */,
 				3D81337F4A5B2C502DB3D076 /* OperationKind.swift */,
 				04781056C289A009489C072C /* OperationWithCounter.swift */,
+				60CCD5574FD830A21601E40E /* OriginationOperation.swift */,
 				9497DCBC4C3BE5334CF8BC59 /* RevealOperation.swift */,
 				9BE79D36BAE8F2465D6231C8 /* SmartContractInvocationOperation.swift */,
 				A84ECF4C95D1743641BEF321 /* TransactionOperation.swift */,
-				C0F9AE5E24098AC4002479FF /* OriginationOperation.swift */,
 			);
 			path = Operation;
 			sourceTree = "<group>";
@@ -1193,11 +1193,11 @@
 				908CE3F01F463AD656302DFD /* MichelsonParameter.swift */,
 				588112F5BDBF5213EB952EF1 /* NoneMichelsonParameter.swift */,
 				F7B9AE14DF5799CA2EEFDCD9 /* PairMichelsonParameter.swift */,
+				A6243223DA0B294EC6B575DF /* RawMichelineMichelsonParameter.swift */,
 				6400970C08C18B3CAD121530 /* RightMichelsonParameter.swift */,
 				CB80D50511873CF9783361B4 /* SomeMichelsonParameter.swift */,
 				3CCF66588A24A65AA37CC90C /* StringMichelsonParameter.swift */,
 				D650111C52C89A65467CC889 /* UnitMichelsonParameter.swift */,
-				C073032E240FEEB8008A9B5B /* RawMichelineMichelsonParameter.swift */,
 			);
 			path = Michelson;
 			sourceTree = "<group>";
@@ -1944,6 +1944,7 @@
 				963E92E6248582A1CD1D9468 /* OperationPayload.swift in Sources */,
 				85BC63DB233D9E4663D05D6B /* OperationPayloadFactory.swift in Sources */,
 				346B3C1348BED784D82EF921 /* OperationWithCounter.swift in Sources */,
+				991D2C7E2C85AF62C0FFF390 /* OriginationOperation.swift in Sources */,
 				F71BD51C6A8C3F5CB182AE41 /* PackDataPayload.swift in Sources */,
 				FBC6C42F1CA1E2C3347610A9 /* PackDataRPC.swift in Sources */,
 				58C7A5EADB3679DB8A4CB288 /* PackDataResponseAdapter.swift in Sources */,
@@ -1957,6 +1958,7 @@
 				77A722B7108EC761FCD7D318 /* PublicKeyProtocol.swift in Sources */,
 				1F1BE8043A523F121852538E /* RPC.swift in Sources */,
 				491266272393A7957B05EC64 /* RPCResponseHandler.swift in Sources */,
+				EE0CEC01367B4514A75342BE /* RawMichelineMichelsonParameter.swift in Sources */,
 				8ADF28B51303B381B5BADF71 /* ResponseAdapter.swift in Sources */,
 				DBB6BA7F5BA4F6525A350D22 /* RevealOperation.swift in Sources */,
 				A28CACC9D1FF82076A876DEE /* RightMichelsonParameter.swift in Sources */,
@@ -1977,7 +1979,6 @@
 				20E9FCE054F634DB3EBE0352 /* StringMichelsonParameter.swift in Sources */,
 				D197ECDB0CE8D9806CA2DF33 /* StringResponseAdapter.swift in Sources */,
 				8A8A0C3FA8BB4D7D06B3BC41 /* Tez.swift in Sources */,
-				C0F9AE5F24098AC5002479FF /* OriginationOperation.swift in Sources */,
 				B00C58996BCA758752DD3B17 /* TezResponseAdapter.swift in Sources */,
 				C6C549A79623A9E2FD3D418E /* TezosKitError.swift in Sources */,
 				EA7CAAC03CEEC69CF5828734 /* TezosNodeClient+Promises.swift in Sources */,
@@ -1988,7 +1989,6 @@
 				B995FA190438FAC10CCCF28B /* TransactionOperation.swift in Sources */,
 				C7EC814C5823F266A4D6E3CF /* TransactionsResponseAdapter.swift in Sources */,
 				2B6489B6FC91E02E2474922C /* UnitMichelsonParameter.swift in Sources */,
-				C073032F240FEEB8008A9B5B /* RawMichelineMichelsonParameter.swift in Sources */,
 				2EA1145A13E79EA9F466EE0B /* Wallet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2168,6 +2168,7 @@
 				B481FCFB6820FB7C37019455 /* OperationPayload.swift in Sources */,
 				F20D1C720BE42B84FF5C3F60 /* OperationPayloadFactory.swift in Sources */,
 				9C490216EE45DD3B2D5FA043 /* OperationWithCounter.swift in Sources */,
+				FC0DA3A41819419D14A44BC8 /* OriginationOperation.swift in Sources */,
 				32D4E01A8FC1F543D5488856 /* PackDataPayload.swift in Sources */,
 				874E720C50CA30079F31F127 /* PackDataRPC.swift in Sources */,
 				23845BE3533EAB49AF8FFB9C /* PackDataResponseAdapter.swift in Sources */,
@@ -2181,6 +2182,7 @@
 				D8D3825EEB92B28B774C544C /* PublicKeyProtocol.swift in Sources */,
 				003826423B0CED390C5BFF08 /* RPC.swift in Sources */,
 				D0504B3FFA0DF83B7DE3A235 /* RPCResponseHandler.swift in Sources */,
+				6544833504DCEFD025688E90 /* RawMichelineMichelsonParameter.swift in Sources */,
 				123CA667757617121345656F /* ResponseAdapter.swift in Sources */,
 				EB8DB4F131248748EB318F10 /* RevealOperation.swift in Sources */,
 				247E267F324622195781C7FC /* RightMichelsonParameter.swift in Sources */,
@@ -2201,7 +2203,6 @@
 				B511E62F850E8E2F3BD41094 /* StringMichelsonParameter.swift in Sources */,
 				B2FF44BEDF48FEE044D2AC91 /* StringResponseAdapter.swift in Sources */,
 				E65D8132F4164B73EF0B68DC /* Tez.swift in Sources */,
-				C0F9AE6024098AC5002479FF /* OriginationOperation.swift in Sources */,
 				4810379C933F3041C8193B3E /* TezResponseAdapter.swift in Sources */,
 				4EE95B692BE0F6AFF3B9AE13 /* TezosKitError.swift in Sources */,
 				4F2F78B301A1CE1C55EE77BA /* TezosNodeClient+Promises.swift in Sources */,
@@ -2212,7 +2213,6 @@
 				108B419FFDA7CF0729F362A8 /* TransactionOperation.swift in Sources */,
 				71E5791297A5DAE0D0D5C9C6 /* TransactionsResponseAdapter.swift in Sources */,
 				775E7DBBE39DCB0644DF5E42 /* UnitMichelsonParameter.swift in Sources */,
-				C0730330240FEEB8008A9B5B /* RawMichelineMichelsonParameter.swift in Sources */,
 				892E99DE1CF34B1762EF4EF1 /* Wallet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2721,7 +2721,7 @@
 				670BAF487C03D0C8DF734AB7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
+			defaultConfigurationName = Debug;
 		};
 		39C44977247E0F96242191CC /* Build configuration list for PBXNativeTarget "TezosKitIntegrationTests_macOS" */ = {
 			isa = XCConfigurationList;
@@ -2730,7 +2730,7 @@
 				2241CF12ED027ABD0A8DF44F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
+			defaultConfigurationName = Debug;
 		};
 		5AE7D52DF5AEC79050B10C6C /* Build configuration list for PBXNativeTarget "SecureEnclaveExample" */ = {
 			isa = XCConfigurationList;
@@ -2739,7 +2739,7 @@
 				25B8AD7D3BFE27A3D79DC395 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
+			defaultConfigurationName = Debug;
 		};
 		719A796CF4303FCE1EA34089 /* Build configuration list for PBXProject "TezosKit" */ = {
 			isa = XCConfigurationList;
@@ -2757,7 +2757,7 @@
 				B37A49D5014B31F5224AFB25 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
+			defaultConfigurationName = Debug;
 		};
 		9A79EB8E61385BC980AF1900 /* Build configuration list for PBXNativeTarget "TezosKitTests_iOS" */ = {
 			isa = XCConfigurationList;
@@ -2766,7 +2766,7 @@
 				BA8998D5B598B6EE0280FBEF /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
+			defaultConfigurationName = Debug;
 		};
 		D5329372F59B0FE5C0A4DE2F /* Build configuration list for PBXNativeTarget "TezosKitTests_macOS" */ = {
 			isa = XCConfigurationList;
@@ -2775,7 +2775,7 @@
 				12ADDB7E17C9B6AEBF98DD2D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
+			defaultConfigurationName = Debug;
 		};
 		E0DE581FD4DB3AD0FF4299D2 /* Build configuration list for PBXNativeTarget "TezosKit_macOS" */ = {
 			isa = XCConfigurationList;
@@ -2784,7 +2784,7 @@
 				70A76F427BE16C8336888BBC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};

--- a/TezosKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/TezosKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:">
+      location = "self:TezosKit.xcodeproj">
    </FileRef>
 </Workspace>

--- a/TezosKit.xcodeproj/xcshareddata/xcschemes/TezosKit_iOS.xcscheme
+++ b/TezosKit.xcodeproj/xcshareddata/xcschemes/TezosKit_iOS.xcscheme
@@ -52,10 +52,6 @@
       </MacroExpansion>
       <CommandLineArguments>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
-      <CodeCoverageTargets>
-      </CodeCoverageTargets>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -78,8 +74,6 @@
       </MacroExpansion>
       <CommandLineArguments>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/TezosKit.xcodeproj/xcshareddata/xcschemes/TezosKit_macOS.xcscheme
+++ b/TezosKit.xcodeproj/xcshareddata/xcschemes/TezosKit_macOS.xcscheme
@@ -52,10 +52,6 @@
       </MacroExpansion>
       <CommandLineArguments>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
-      <CodeCoverageTargets>
-      </CodeCoverageTargets>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -78,8 +74,6 @@
       </MacroExpansion>
       <CommandLineArguments>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/TezosKit/Crypto/SecretKey.swift
+++ b/TezosKit/Crypto/SecretKey.swift
@@ -99,8 +99,6 @@ public struct SecretKey {
   ///    - bytes: Raw bytes of the private key.
   ///    - signingCurve: The elliptical curve to use for the key. Defaults to ed25519.
   public init(_ bytes: [UInt8], signingCurve: EllipticalCurve = .ed25519) {
-    print("byte size: \(bytes.count)")
-
     self.bytes = bytes
     self.signingCurve = signingCurve
   }

--- a/TezosKit/Crypto/SecretKey.swift
+++ b/TezosKit/Crypto/SecretKey.swift
@@ -57,7 +57,7 @@ public struct SecretKey {
       return nil
     }
 
-    self.init(keyPair.secretKey, signingCurve: .ed25519)
+    self.init(keyPair.secretKey, signingCurve: signingCurve)
   }
 
   /// Initialize a secret key with the given base58check encoded string.

--- a/TezosKit/Crypto/SecretKey.swift
+++ b/TezosKit/Crypto/SecretKey.swift
@@ -57,7 +57,19 @@ public struct SecretKey {
       return nil
     }
 
-    self.init(keyPair.secretKey, signingCurve: signingCurve)
+    // Key is 64 bytes long. The first 32 bytes are the private key. Sodium, the ed25519 library expects extended
+    // private keys, so pass down the full 64 bytes.
+    let secretKeyBytes = keyPair.secretKey
+    switch signingCurve {
+    case .ed25519:
+      self.init(secretKeyBytes, signingCurve: signingCurve)
+    case .secp256k1:
+      let privateKeyBytes = Array(secretKeyBytes[..<32])
+      self.init(privateKeyBytes, signingCurve: signingCurve)
+    case .p256:
+      fatalError("unimplemented")
+    }
+
   }
 
   /// Initialize a secret key with the given base58check encoded string.
@@ -87,6 +99,8 @@ public struct SecretKey {
   ///    - bytes: Raw bytes of the private key.
   ///    - signingCurve: The elliptical curve to use for the key. Defaults to ed25519.
   public init(_ bytes: [UInt8], signingCurve: EllipticalCurve = .ed25519) {
+    print("byte size: \(bytes.count)")
+
     self.bytes = bytes
     self.signingCurve = signingCurve
   }


### PR DESCRIPTION
The underlying implementation of secret key always defaulted back to the `ed25519` `SigningCurve`. Fix this bug. 

Add tests at the `Wallet` level to verify that wallet derivation with these curves works end to end when using either mnemonic/passphrase based generation or when using secret key generation. 