### PR TITLE
Disallow Negative Tez values

### DIFF
--- a/Tests/UnitTests/TezosKit/TezTest.swift
+++ b/Tests/UnitTests/TezosKit/TezTest.swift
@@ -5,8 +5,10 @@ import XCTest
 
 class TezTest: XCTestCase {
   public func testHumanReadableRepresentationWithDecimalNumber() {
-    guard let balanceFromStringNoLeadingZeros = Tez("3500000"),
-      let balanceFromStringLeadingZeros = Tez("3050000") else {
+    guard
+      let balanceFromStringNoLeadingZeros = Tez("3500000"),
+      let balanceFromStringLeadingZeros = Tez("3050000")
+    else {
       XCTFail()
       return
     }
@@ -21,8 +23,10 @@ class TezTest: XCTestCase {
   }
 
   public func testRPCRepresentationWithDecimalNumber() {
-    guard let balanceFromStringNoLeadingZeros = Tez("3500000"),
-      let balanceFromStringLeadingZeros = Tez("3050000") else {
+    guard
+      let balanceFromStringNoLeadingZeros = Tez("3500000"),
+      let balanceFromStringLeadingZeros = Tez("3050000")
+    else {
       XCTFail()
       return
     }
@@ -37,7 +41,9 @@ class TezTest: XCTestCase {
   }
 
   public func testHumanReadableRepresentationWithWholeNumber() {
-    guard let balanceFromString = Tez("3000000") else {
+    guard
+      let balanceFromString = Tez("3000000")
+    else {
       XCTFail()
       return
     }
@@ -48,7 +54,9 @@ class TezTest: XCTestCase {
   }
 
   public func testRPCRepresentationWithWholeNumber() {
-    guard let balanceFromString = Tez("3000000") else {
+    guard
+      let balanceFromString = Tez("3000000")
+    else {
       XCTFail()
       return
     }
@@ -59,7 +67,9 @@ class TezTest: XCTestCase {
   }
 
   public func testRPCRepresentationWithSmallNumber() {
-    guard let balanceFromString = Tez("10") else {
+    guard
+      let balanceFromString = Tez("10")
+    else {
       XCTFail()
       return
     }
@@ -70,7 +80,9 @@ class TezTest: XCTestCase {
   }
 
   public func testHumanReadableRepresentationWithSmallNumber() {
-    guard let balanceFromString = Tez("10") else {
+    guard
+      let balanceFromString = Tez("10")
+    else {
       XCTFail()
       return
     }
@@ -178,15 +190,12 @@ class TezTest: XCTestCase {
   }
 
   public func testSubtractTwoDecimalsWithCarry() {
-    var left = Tez(4.3)
+    let left = Tez(4.3)
     let right = Tez(1.6)
     let expected = Tez(2.7)
 
     let actual = left - right
     XCTAssertEqual(actual, expected)
-
-    left -= right
-    XCTAssertEqual(left, expected)
   }
 
   public func testGreaterThan() {

--- a/TezosKit/TezosNode/Services/DefaultFeeProvider.swift
+++ b/TezosKit/TezosNode/Services/DefaultFeeProvider.swift
@@ -77,13 +77,13 @@ public class DefaultFeeProvider {
         gasLimit: 10_307,
         storageLimit: 257
       )
-	// TODO(keefertaylor): Something more sane here
-	case .origination:
-	  return OperationFees(
-		fee: Tez(0.001_284),
-		gasLimit: 10_200,
-		storageLimit: 257
-	  )
+    // TODO(keefertaylor): Something more sane here
+    case .origination:
+      return OperationFees(
+        fee: Tez(0.001_284),
+        gasLimit: 10_200,
+        storageLimit: 257
+      )
     }
   }
 
@@ -108,7 +108,7 @@ public class DefaultFeeProvider {
         gasLimit: 10_307,
         storageLimit: 257
       )
-	// TODO(keefertaylor): Something more sane here
+    // TODO(keefertaylor): Something more sane here
     case .origination:
       return OperationFees(
         fee: Tez(0.001_284),

--- a/TezosKit/TezosNode/Services/FeeEstimator.swift
+++ b/TezosKit/TezosNode/Services/FeeEstimator.swift
@@ -27,6 +27,7 @@ public class FeeEstimator {
   private enum SafetyMargin {
     public static let gas = 100
     public static let storage = 257
+
     public static let fee = Tez(0.000_100)
   }
 


### PR DESCRIPTION
Re-work `Tez` to work with unsigned integers since it is invalid to have a negative amount of Tez. 