### PR TITLE
Allow unbounded `int` and `nat` michelson types.

### DIFF
--- a/TezosKit/Common/Michelson/IntMichelsonParameter.swift
+++ b/TezosKit/Common/Michelson/IntMichelsonParameter.swift
@@ -1,14 +1,37 @@
 // Copyright Keefer Taylor, 2019.
 
+import BigInt
 import Foundation
 
 /// A representation of an integer parameter in Michelson.
 public class IntMichelsonParameter: AbstractMichelsonParameter {
-  public init(int: Int, annotations: [MichelsonAnnotation]? = nil) {
-    super.init(networkRepresentation: [MichelineConstants.int: "\(int)"], annotations: annotations)
+  /// Initialize a represenation of an integer using an `Int`.
+  ///
+  /// Note that the michelson int type is unbounded while `Int` values have bounded precision. Consider  using the `init(bigInt:annotations:)`
+  /// to represent a full range of values.
+  public convenience init(int: Int, annotations: [MichelsonAnnotation]? = nil) {
+    self.init(string: String(int), annotations: annotations)
   }
 
-  public init(decimal: Decimal, annotations: [MichelsonAnnotation]? = nil) {
-    super.init(networkRepresentation: [MichelineConstants.int: "\(decimal)"], annotations: annotations)
+  /// Initialize a represenation of an integer using a `Decimal`.
+  ///
+  /// Note that the michelson int type is unbounded while `Decimal` values have bounded precision. Consider  using the `init(bigInt:annotations:)`
+  /// to represent a full range of values.
+  public convenience init(decimal: Decimal, annotations: [MichelsonAnnotation]? = nil) {
+    self.init(string: "\(decimal)", annotations: annotations)
+  }
+
+  /// Initialize a represenation of an integer using an `BigInt`.
+  public convenience init(bigInt: BigInt, annotations: [MichelsonAnnotation]? = nil) {
+    self.init(string: String(bigInt), annotations: annotations)
+  }
+
+  /// Internal initializer.
+  ///
+  /// - Parameters:
+  ///   - string: A numerical string representing the precision.
+  ///   - annotations: An array of annotations to apply to the parameter. Defaults to no annotations.
+  private init(string: String, annotations: [MichelsonAnnotation]? = nil) {
+    super.init(networkRepresentation: [MichelineConstants.int: string], annotations: annotations)
   }
 }


### PR DESCRIPTION
Int / Nat numbers in Michelson have unbounded precision.  Modify initializer to take a `BigInt`  which allows for arbitrary precision. 

Decimal / Int based initializers are left in place since they are likely used by external clients and are useful shorthand for clients who don't need arbitrary precision. 