### PR TITLE
Add warning about storing keys in memory

### DIFF
--- a/TezosKit/Common/Models/Wallet.swift
+++ b/TezosKit/Common/Models/Wallet.swift
@@ -6,6 +6,10 @@ import Foundation
 ///
 /// Clients can create a new wallet by calling the empty initializer. Clients can also restore an existing wallet by
 /// providing an mnemonic and optional passphrase.
+///
+/// - Warning: This class stores a secret key in memory. It is possible that memory can be compromised and that the secret key can be read, even after this
+///            object is deallocated. For more information, see Apple's guidelines on password handling:
+///            https://developer.apple.com/library/archive/documentation/Security/Conceptual/SecureCodingGuide/SecurityDevelopmentChecklists/SecurityDevelopmentChecklists.html#//apple_ref/doc/uid/TP40002415-CH1-SW6
 public struct Wallet {
   /// Keys for the wallet.
   public let publicKey: PublicKeyProtocol


### PR DESCRIPTION
As recommended by the LeastAuthority audit team.