### PR TITLE
Operation error handling update

### DIFF
--- a/TezosKit/TezosNode/Services/RPCResponseHandler.swift
+++ b/TezosKit/TezosNode/Services/RPCResponseHandler.swift
@@ -41,7 +41,7 @@ public class RPCResponseHandler {
     // TODO(keefertaylor): Add a test for this logic.
     do {
       let operationResult = try JSONDecoder().decode(OperationResponse.self, from: data)
-      if operationResult.isBacktracked() {
+      if operationResult.isFailed() {
         return .failure(.operationError(operationResult.errors()))
       }
     } catch {


### PR DESCRIPTION
The error object appears in different locations depending on the type of request. During simulation the errors appear inside `OperationResult` during injection they appear inside `InternalOperationResult`. Made some fields optional and updated the function to find all these errors and extract.

Detailed errors are now propagating up through the chain